### PR TITLE
refactor!: support importing every entrypoints at once

### DIFF
--- a/src/ViteServiceProvider.php
+++ b/src/ViteServiceProvider.php
@@ -25,14 +25,14 @@ class ViteServiceProvider extends PackageServiceProvider
 
         Blade::directive('vite', function ($entryName = null) {
             if (! $entryName) {
-                return sprintf('<?php echo vite_client() ?>');
+                return '<?php echo vite_tags() ?>';
             }
 
             return sprintf('<?php echo vite_entry(e(%s)); ?>', $entryName);
         });
 
-        Blade::directive('entry', function ($entryName = null) {
-            return sprintf('<?php echo vite_entry(e(%s)); ?>', $entryName);
+        Blade::directive('client', function () {
+            return '<?php echo vite_client(); ?>';
         });
     }
 }

--- a/src/helpers.php
+++ b/src/helpers.php
@@ -23,3 +23,15 @@ if (! function_exists('vite_entry')) {
         return app()->make(Innocenzi\Vite\Vite::class)->getEntry($entry);
     }
 }
+
+if (! function_exists('vite_tags')) {
+    /**
+     * Get the HTML tags for the Vite client and every configured entrypoint.
+     *
+     * @return string
+     */
+    function vite_tags()
+    {
+        return app()->make(Innocenzi\Vite\Vite::class)->getClientAndEntrypointTags();
+    }
+}

--- a/tests/Unit/BladeDirectivesTest.php
+++ b/tests/Unit/BladeDirectivesTest.php
@@ -8,15 +8,20 @@ beforeEach(function () {
 
 it('creates directives', function () {
     expect(test()->directives)
-        ->toHaveKeys(['vite', 'entry']);
+        ->toHaveKeys(['vite', 'client']);
 });
 
-it('generates the client script from the directive', function () {
+it('generates a call to vite_tags() from the @vite directive when there is no parameters', function () {
     expect(test()->directives['vite']())
-        ->toBe('<?php echo vite_client() ?>');
+        ->toBe('<?php echo vite_tags() ?>');
 });
 
-it('generates an script from the directive', function () {
+it('generates a call to vite_entry() from the @vite directive when there is a parameter', function () {
     expect(test()->directives['vite']('resources/ts/main.ts'))
         ->toBe('<?php echo vite_entry(e(resources/ts/main.ts)); ?>');
+});
+
+it('generates a call to vite_client() from the @client directive', function () {
+    expect(test()->directives['client']())
+        ->toBe('<?php echo vite_client(); ?>');
 });

--- a/tests/Unit/ViteTest.php
+++ b/tests/Unit/ViteTest.php
@@ -18,8 +18,8 @@ it('does not generate the client script in a production environment', function (
 
 it('generates an entry script in a local environment', function () {
     set_env('local');
-    expect(get_vite()->getEntry('some/path/scrip.ts'))
-        ->toEqual('<script type="module" src="http://localhost:3000/some/path/scrip.ts"></script>');
+    expect(get_vite()->getEntry('some/path/script.ts'))
+        ->toEqual('<script type="module" src="http://localhost:3000/some/path/script.ts"></script>');
 });
 
 it('throws when generating a non-existing entry script in a production environment', function () {
@@ -45,4 +45,23 @@ it('finds an entrypoint by its name when its directory is registered in the conf
     App::setBasePath(__DIR__);
     expect(get_vite('with_css.json')->getEntry('entry.ts'))
         ->toEqual('<script type="module" src="http://localhost:3000/scripts/entry.ts"></script>');
+});
+
+it('finds every entrypoints and generates their tags along with the client in a development environment', function () {
+    set_env('local');
+    Config::set('vite.entrypoints', 'scripts');
+    App::setBasePath(__DIR__);
+    expect(get_vite()->getClientAndEntrypointTags())
+        ->toEqual(implode('', [
+            '<script type="module" src="http://localhost:3000/@vite/client"></script>',
+            '<script type="module" src="http://localhost:3000/scripts/entry.ts"></script>',
+        ]));
+});
+
+it('does not generate client script tag in production environment', function () {
+    set_env('production');
+    Config::set('vite.entrypoints', 'scripts');
+    App::setBasePath(__DIR__);
+    expect(get_vite()->getClientAndEntrypointTags())
+        ->toEqual('<script src="/build/app.83b2e884.js"></script>');
 });


### PR DESCRIPTION
This replaces the original `@vite` directive behavior.
Instead, `@client` must be used.

Now, you only need `@vite` in your Blade file to include every automatic entrypoint. 
If you have different entry points configured in `vite.config.ts`, they'll need to be included manually with `@vite('relative/path/to/script.ts')`.

Closes #5.