### PR TITLE
feat!: support `ASSET_URL` environment variable

### DIFF
--- a/npm/package.json
+++ b/npm/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "laravel-vite",
-	"version": "0.0.1-dev.5",
+	"version": "0.0.1-dev.6",
 	"author": "Enzo Innocenzi",
 	"license": "MIT",
 	"main": "dist/index.js",
@@ -24,10 +24,12 @@
 		"@types/node": "^14.14.25",
 		"tsup": "^3.7.0",
 		"typescript": "^4.1.4",
-		"vite": "^2.0.0-beta.67"
+		"vite": "^2.0.0-beta.69"
 	},
 	"dependencies": {
+		"chalk": "^4.1.0",
 		"deepmerge": "^4.2.2",
+		"dotenv": "^8.2.0",
 		"execa": "^5.0.0",
 		"fast-glob": "^3.2.5"
 	}

--- a/npm/yarn.lock
+++ b/npm/yarn.lock
@@ -262,6 +262,11 @@ dir-glob@^3.0.1:
   dependencies:
     path-type "^4.0.0"
 
+dotenv@^8.2.0:
+  version "8.2.0"
+  resolved "https://registry.yarnpkg.com/dotenv/-/dotenv-8.2.0.tgz#97e619259ada750eea3e4ea3e26bceea5424b16a"
+  integrity sha512-8sJ78ElpbDJBHNeBzUbUVLsqKdccaa/BXF1uPTw3GrvQTBgrQrtObr2mUrE38vzYd8cEv+m/JBfDLioYcfXoaw==
+
 error-ex@^1.3.1:
   version "1.3.2"
   resolved "https://registry.yarnpkg.com/error-ex/-/error-ex-1.3.2.tgz#b4ac40648107fdcdcfae242f428bea8a14d4f1bf"
@@ -832,10 +837,10 @@ typescript@^4.1.4:
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.1.4.tgz#f058636e2f4f83f94ddaae07b20fd5e14598432f"
   integrity sha512-+Uru0t8qIRgjuCpiSPpfGuhHecMllk5Zsazj5LZvVsEStEjmIRRBZe+jHjGQvsgS7M1wONy2PQXd67EMyV6acg==
 
-vite@^2.0.0-beta.67:
-  version "2.0.0-beta.67"
-  resolved "https://registry.yarnpkg.com/vite/-/vite-2.0.0-beta.67.tgz#2d4e7a62a925539448bd18154008afb2b4484a07"
-  integrity sha512-QNxIRajidVG3ejikBUb17NgCV1bJ9UyKHBdItgw1O/ljQ1hBoph5I2/DrviqV4G9H3WP7teXk5vwQWuCVS9fqQ==
+vite@^2.0.0-beta.69:
+  version "2.0.0-beta.69"
+  resolved "https://registry.yarnpkg.com/vite/-/vite-2.0.0-beta.69.tgz#dd10b4c366d64e670a0da612097fe9645c40212b"
+  integrity sha512-Wf4bWOK/b6Q+06Wyk7uJIBy/LiENGx26do6tn9gOMRRZLEuLizN/cDzGqnQkGVVevbb18xdilyxhnTes0lFjZg==
   dependencies:
     esbuild "^0.8.34"
     postcss "^8.2.1"

--- a/src/ManifestEntry.php
+++ b/src/ManifestEntry.php
@@ -64,7 +64,7 @@ class ManifestEntry implements Htmlable, Stringable
      */
     protected function asset(string $path): string
     {
-        return sprintf('/%s/%s', \config('vite.build_path'), $path);
+        return asset(sprintf('/%s/%s', config('vite.build_path'), $path));
     }
 
     /**

--- a/src/Vite.php
+++ b/src/Vite.php
@@ -87,9 +87,11 @@ class Vite
 
     protected function createDevelopmentScriptTag(string $path): Htmlable
     {
+        // I suspect ASSET_URL should be takin into account here.
+        // If you find out it does, feel free to open an issue.
         return new HtmlString(sprintf(
-            '<script type="module" src="%s/%s"></script>',
-            \config('vite.dev_url'),
+            '<script type="module" src="%s%s"></script>',
+            Str::finish(\config('vite.dev_url'), '/'),
             $path
         ));
     }


### PR DESCRIPTION
This creates support for the `ASSET_URL` environment variable, just like Laravel's `asset` helper. This updates Vite's `base` property. In development, this is ignored.

Closes #6.