### PR TITLE
fix: support entrypoints by name in production

### DIFF
--- a/src/Exceptions/NoSuchEntrypointException.php
+++ b/src/Exceptions/NoSuchEntrypointException.php
@@ -6,6 +6,6 @@ class NoSuchEntrypointException extends \Exception
 {
     public function __construct(string $entry)
     {
-        $this->message = "${entry} does not exist in the manifest. Make sure you added an entry point in the Vite configuration.";
+        $this->message = "'${entry}' does not exist in the manifest. Make sure you added an entry point in the Vite configuration.";
     }
 }

--- a/src/Manifest.php
+++ b/src/Manifest.php
@@ -4,6 +4,7 @@ namespace Innocenzi\Vite;
 
 use Illuminate\Contracts\Support\Htmlable;
 use Illuminate\Support\Collection;
+use Illuminate\Support\Str;
 use Innocenzi\Vite\Exceptions\ManifestNotFound;
 use Innocenzi\Vite\Exceptions\NoSuchEntrypointException;
 use Stringable;
@@ -39,13 +40,13 @@ class Manifest implements Htmlable, Stringable
     /**
      * Gets the manifest entry for the given name.
      */
-    public function getEntry(string $entry): ManifestEntry
+    public function getEntry(string $name): ManifestEntry
     {
-        if (! $this->entries->has($entry)) {
-            throw new NoSuchEntrypointException($entry);
+        if (! $entry = $this->entries->first(fn (ManifestEntry $entry) => Str::contains($entry->src, $name))) {
+            throw new NoSuchEntrypointException($name);
         }
 
-        return $this->entries->get($entry);
+        return $entry;
     }
 
     /**

--- a/tests/Unit/ViteTest.php
+++ b/tests/Unit/ViteTest.php
@@ -39,12 +39,20 @@ it('generates scripts and css from an entry point in a production environment', 
         ->toEqual('<script type="module" src="http://localhost/build/app.83b2e884.js"></script><link rel="stylesheet" href="http://localhost/build/app.e33dabbf.css" />');
 });
 
-it('finds an entrypoint by its name when its directory is registered in the configuration', function () {
+it('finds an entrypoint by its name when its directory is registered in the configuration in a local environment', function () {
     set_env('local');
     Config::set('vite.entrypoints', 'scripts');
     App::setBasePath(__DIR__);
-    expect(get_vite('with_css.json')->getEntry('entry.ts'))
+    expect(get_vite('entry.json')->getEntry('entry.ts'))
         ->toEqual('<script type="module" src="http://localhost:3000/scripts/entry.ts"></script>');
+});
+
+it('finds an entrypoint by its name when its directory is registered in the configuration in a production environment', function () {
+    set_env('production');
+    Config::set('vite.entrypoints', 'scripts');
+    App::setBasePath(__DIR__);
+    expect(get_vite('entry.json')->getEntry('entry.ts'))
+        ->toEqual('<script type="module" src="http://localhost/build/entry.2615a355.js"></script>');
 });
 
 it('finds every entrypoints and generates their tags along with the client in a development environment', function () {

--- a/tests/Unit/manifests/entry.json
+++ b/tests/Unit/manifests/entry.json
@@ -1,0 +1,7 @@
+{
+	"resources/scripts/entry.ts": {
+		"file": "entry.2615a355.js",
+		"src": "resources/scripts/entry.ts",
+		"isEntry": true
+	}
+}


### PR DESCRIPTION
This fixes an error that occured if you used the convenience "entrypoint by name instead of path" feature in production.