### PR TITLE
fix: properly filter entrypoints for build-time

### DIFF
--- a/npm/package.json
+++ b/npm/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "laravel-vite",
-	"version": "0.0.3",
+	"version": "0.0.4",
 	"author": "Enzo Innocenzi",
 	"license": "MIT",
 	"main": "dist/index.js",
@@ -32,7 +32,6 @@
 		"chalk": "^4.1.0",
 		"deepmerge": "^4.2.2",
 		"dotenv": "^8.2.0",
-		"execa": "^5.0.0",
-		"fast-glob": "^3.2.5"
+		"execa": "^5.0.0"
 	}
 }

--- a/npm/src/index.ts
+++ b/npm/src/index.ts
@@ -2,7 +2,6 @@ import path from 'path'
 import { Plugin, UserConfig } from 'vite'
 import deepmerge from 'deepmerge'
 import execa from 'execa'
-import fs from 'fast-glob'
 import chalk from 'chalk'
 import dotenv from 'dotenv'
 
@@ -79,22 +78,8 @@ export class ViteConfiguration {
 			}
 		}
 
-		if (artisan?.entrypoints) {
-			const directories = !Array.isArray(artisan.entrypoints)
-				? [artisan.entrypoints]
-				: artisan.entrypoints
-
-			const matches = fs.sync(
-				directories.map(directory => `${directory}/*`),
-				{
-					onlyFiles: true,
-					globstar: false,
-					dot: false,
-				},
-			);
-
-			(this.build.rollupOptions!.input! as string[]).push(...matches)
-		}
+		if (artisan?.entrypoints)
+			(this.build.rollupOptions!.input! as string[]).push(...artisan.entrypoints)
 
 		this.merge(config)
 	}

--- a/npm/yarn.lock
+++ b/npm/yarn.lock
@@ -1063,7 +1063,7 @@ fast-deep-equal@^3.1.1:
   resolved "https://registry.yarnpkg.com/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz#3a7d56b559d6cbc3eb512325244e619a65c6c525"
   integrity sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==
 
-fast-glob@^3.1.1, fast-glob@^3.2.5:
+fast-glob@^3.1.1:
   version "3.2.5"
   resolved "https://registry.yarnpkg.com/fast-glob/-/fast-glob-3.2.5.tgz#7939af2a656de79a4f1901903ee8adcaa7cb9661"
   integrity sha512-2DtFcgT68wiTTiwZ2hNdJfcHNke9XOfnwmBRWXhmeKM8rF0TGwmC/Qto3S7RoZKp5cilZbxzO5iTNTQsJ+EeDg==

--- a/src/Commands/ExportConfigurationCommand.php
+++ b/src/Commands/ExportConfigurationCommand.php
@@ -3,6 +3,8 @@
 namespace Innocenzi\Vite\Commands;
 
 use Illuminate\Console\Command;
+use Illuminate\Support\Str;
+use Innocenzi\Vite\Vite;
 
 class ExportConfigurationCommand extends Command
 {
@@ -12,6 +14,20 @@ class ExportConfigurationCommand extends Command
 
     public function handle()
     {
-        $this->output->write(json_encode(\config('vite')));
+        $this->output->write($this->getConfigurationAsJson());
+    }
+
+    public function getConfigurationAsJson(): string
+    {
+        $entrypoints = app(Vite::class)->findEntrypoints()
+            ->map(fn (\SplFileInfo $file) => Str::of($file->getPathname())
+            ->replace(\base_path(), '')
+            ->replace('\\', '/')
+            ->ltrim('/'))
+            ->values();
+
+        return json_encode(array_merge(config('vite'), [
+            'entrypoints' => $entrypoints,
+        ]));
     }
 }

--- a/src/Vite.php
+++ b/src/Vite.php
@@ -66,6 +66,20 @@ class Vite
             return $this->getManifest()->getEntries();
         }
 
+        return $this->findEntrypoints()
+            ->map(fn (\SplFileInfo $file) => $this->createDevelopmentScriptTag(
+                Str::of($file->getPathname())
+                    ->replace(\base_path(), '')
+                    ->replace('\\', '/')
+                    ->ltrim('/')
+            ));
+    }
+
+    /**
+     * Finds entrypoints from the configuration.
+     */
+    public function findEntrypoints(): Collection
+    {
         $paths = collect(\config('vite.entrypoints', []))
             ->map(fn ($directory) => \base_path($directory));
 
@@ -74,13 +88,7 @@ class Vite
             ->merge($paths->filter(fn ($directory) => File::isFile($directory))->map(fn (string $path) => new \SplFileInfo($path)))
             ->unique(fn (\SplFileInfo $file) => $file->getPathname())
             ->filter(fn (\SplFileInfo $file) => ! collect(config('vite.ignore_patterns'))
-            ->some(fn ($pattern) => preg_match($pattern, $file->getFilename())))
-            ->map(fn (\SplFileInfo $file) => $this->createDevelopmentScriptTag(
-                Str::of($file->getPathname())
-                    ->replace(\base_path(), '')
-                    ->replace('\\', '/')
-                    ->ltrim('/')
-            ));
+            ->some(fn ($pattern) => preg_match($pattern, $file->getFilename())));
     }
 
     /**

--- a/tests/Features/ExportConfigurationCommandTest.php
+++ b/tests/Features/ExportConfigurationCommandTest.php
@@ -1,7 +1,11 @@
 <?php
 
+use Innocenzi\Vite\Commands\ExportConfigurationCommand;
+
 it('exposes the configuration contents to the command line', function () {
+    $output = app(ExportConfigurationCommand::class)->getConfigurationAsJson();
+
     test()->artisan('vite:config')
-        ->expectsOutput(\json_encode(\config('vite'), true))
+        ->expectsOutput($output)
         ->assertExitCode(0);
 });


### PR DESCRIPTION
This PR fixes the fact that the production build did not take into account the filter in the configuration.