### PR TITLE
feat: support react refresh runtime

### DIFF
--- a/docs/guide/usage.md
+++ b/docs/guide/usage.md
@@ -78,6 +78,10 @@ Note that in order to enable Hot Module Replacement, you need to include the cli
 
 This directive includes the client script. It is not needed if you used `@vite` without parameters, but it is needed otherwise.
 
+### `@react`
+
+This directive includes React's refresh runtime. It is not needed if you don't use React, and it must be added **before** `@vite` or `@client`.
+
 ## Import aliases
 
 For convenience, the `@` alias is configured to point to the `resources` directory. This can be edited in the [configuration](/guide/configuration#aliases).

--- a/src/Vite.php
+++ b/src/Vite.php
@@ -41,7 +41,29 @@ class Vite
             return new HtmlString();
         }
 
-        return $this->getEntry('@vite/client');
+        return $this->createDevelopmentScriptTag('@vite/client');
+    }
+
+    /**
+     * Gets the script tag for React's refresh runtime.
+     */
+    public function getReactRefreshRuntimeScript(): Htmlable
+    {
+        if (! $this->isDevelopmentServerRunning()) {
+            return new HtmlString();
+        }
+
+        $script = <<<HTML
+        <script type="module">
+            import RefreshRuntime from "http://localhost:3000/@react-refresh"
+            RefreshRuntime.injectIntoGlobalHook(window) 
+            window.\$RefreshReg$ = () => {}
+            window.\$RefreshSig$ = () => (type) => type
+            window.__vite_plugin_react_preamble_installed__ = true
+        </script>
+        HTML;
+
+        return new HtmlString($script);
     }
 
     /**

--- a/src/ViteServiceProvider.php
+++ b/src/ViteServiceProvider.php
@@ -34,5 +34,9 @@ class ViteServiceProvider extends PackageServiceProvider
         Blade::directive('client', function () {
             return '<?php echo vite_client(); ?>';
         });
+
+        Blade::directive('react', function () {
+            return '<?php echo vite_react_refresh_runtime(); ?>';
+        });
     }
 }

--- a/src/helpers.php
+++ b/src/helpers.php
@@ -12,6 +12,18 @@ if (! function_exists('vite_client')) {
     }
 }
 
+if (! function_exists('vite_react_refresh_runtime')) {
+    /**
+     * Get the HTML script tag that includes the Vite client.
+     *
+     * @return string
+     */
+    function vite_react_refresh_runtime()
+    {
+        return app()->make(Innocenzi\Vite\Vite::class)->getReactRefreshRuntimeScript();
+    }
+}
+
 if (! function_exists('vite_entry')) {
     /**
      * Get the HTML tags that include the given entry.

--- a/tests/Unit/BladeDirectivesTest.php
+++ b/tests/Unit/BladeDirectivesTest.php
@@ -25,3 +25,8 @@ it('generates a call to vite_client() from the @client directive', function () {
     expect(test()->directives['client']())
         ->toBe('<?php echo vite_client(); ?>');
 });
+
+it('generates a call to vite_react_refresh_runtime() from the @react directive', function () {
+    expect(test()->directives['react']())
+        ->toBe('<?php echo vite_react_refresh_runtime(); ?>');
+});


### PR DESCRIPTION
This PR adds support for injecting React's refresh runtime when using the `@react` directive. This directive must be positionned before the other ones. 

A new directive was needed because there was no way of detecting the use of React from PHP.

Closes #32 