### PR TITLE
feat: add `vite_asset` helper

### DIFF
--- a/config/vite.php
+++ b/config/vite.php
@@ -3,35 +3,6 @@
 return [
     /*
     |--------------------------------------------------------------------------
-    | Build path
-    |--------------------------------------------------------------------------
-    | The directory, relative to /public, in which Vite will build
-    | the production files. This should match "build.outDir" in the Vite
-    | configuration file.
-    */
-    'build_path' => 'build',
-
-    /*
-    |--------------------------------------------------------------------------
-    | Development URL
-    |--------------------------------------------------------------------------
-    | The URL at which the Vite development server runs.
-    | This is used to generate the script tags when developing.
-    */
-    'dev_url' => 'http://localhost:3000',
-
-    /*
-    |--------------------------------------------------------------------------
-    | Ping timeout
-    |--------------------------------------------------------------------------
-    | The maximum duration, in seconds, that the ping to the development
-    | server should take while trying to determine whether to use the
-    | manifest or the server in a local environment.
-    */
-    'ping_timeout' => .1,
-
-    /*
-    |--------------------------------------------------------------------------
     | Entrypoints
     |--------------------------------------------------------------------------
     | The files in the configured directories will be considered
@@ -54,4 +25,44 @@ return [
     'aliases' => [
         '@' => 'resources',
     ],
+
+    /*
+    |--------------------------------------------------------------------------
+    | Static assets path
+    |--------------------------------------------------------------------------
+    | This option defines the directory that Vite considers as the
+    | public directory. Its content will be copied to the build directory
+    | at build-time.
+    | https://vitejs.dev/config/#publicdir
+    */
+    'public_directory' => resource_path('static'),
+
+    /*
+    |--------------------------------------------------------------------------
+    | Ping timeout
+    |--------------------------------------------------------------------------
+    | The maximum duration, in seconds, that the ping to the development
+    | server should take while trying to determine whether to use the
+    | manifest or the server in a local environment.
+    */
+    'ping_timeout' => .1,
+
+    /*
+    |--------------------------------------------------------------------------
+    | Build path
+    |--------------------------------------------------------------------------
+    | The directory, relative to /public, in which Vite will build
+    | the production files. This should match "build.outDir" in the Vite
+    | configuration file.
+    */
+    'build_path' => 'build',
+
+    /*
+    |--------------------------------------------------------------------------
+    | Development URL
+    |--------------------------------------------------------------------------
+    | The URL at which the Vite development server runs.
+    | This is used to generate the script tags when developing.
+    */
+    'dev_url' => 'http://localhost:3000',
 ];

--- a/docs/guide/configuration.md
+++ b/docs/guide/configuration.md
@@ -15,20 +15,6 @@ php artisan vendor:publish --tag=laravel-vite-config
 
 ## Options
 
-### `build_path`
-
-- **Default**: `build`
-
-This option configures the directory in which the assets will be built, relative to the `public` directory. It should not be empty, as the build directory is cleared by Vite upon asset generation, which would erase existing public files such as `index.php`.
-
-It is best not to change this option unless you have a specific requirement.
-
-### `dev_url`
-
-- **Default**: `http://localhost:3000`
-
-When using Vite in development, assets must link to the development server. This option is used for this purpose, and will also be injected in Vite's configuration. If, for instance, you have multiple Vite servers running on your machine, you may want to update `dev_url` to `http://localhost:3001`.
-
 ### `entrypoints`
 
 - **Default**: `[ 'resources/scripts', 'resources/js' ]`
@@ -40,13 +26,53 @@ You can disable this feature by setting the option to `false`.
 
 It is recommended to only use `resources/scripts`, unless you have specific requirements.
 
+### `ignore_patterns`
+
+- **Defaults**: `["/\.d\.ts$/"]`
+- **Type**: `RegExp[]`
+
+This option defines the regular expressions that filter out files found in the `entrypoints` directories. By default, files ending with `.d.ts` will be ignored, so you can have type definitions in your `scripts` directory.
+
 ### `aliases`
 
 - **Default**: `[ '@' => 'resources' ]`
+- **Type**: `Record<string, string>`
 
 This option defines aliases that will be added to Vite's configuration. Additionally, in order to support Visual Studio Code, starting the development server while having aliases will update the `tsconfig.json` file (or create one if it does not exist) with the configured aliases.
 
 Note that you can manually generate or update this file with the `vite:aliases` Artisan command.
+
+### `public_directory`
+
+- **Default**: `resources/static`
+- **Type**: `string`
+
+This option defines the directory that Vite considers as the public directory. Its content will be copied to the build directory at build-time. Note that this should not be set to `public`, otherwise there will be a copy loop.
+
+This option directly maps to Vite's [`publicDir`](https://vitejs.dev/config/#publicdir).
+
+### `build_path`
+
+- **Default**: `build`
+- **Type**: `string`
+
+This option configures the directory in which the assets will be built, relative to the `public` directory. It should not be empty, as the build directory is cleared by Vite upon asset generation, which would erase existing public files such as `index.php`.
+
+It is best not to change this option unless you have a specific requirement.
+
+### `dev_url`
+
+- **Default**: `http://localhost:3000`
+- **Type**: `string`
+
+When using Vite in development, assets must link to the development server. This option is used for this purpose, and will also be injected in Vite's configuration. If, for instance, you have multiple Vite servers running on your machine, you may want to update `dev_url` to `http://localhost:3001`.
+
+### `ping_timeout`
+
+- **Default**: `0.1`
+- **Type**: `number`
+
+This defines the maximum duration, in seconds, that the ping to the development server should take while trying to determine whether to use the manifest or the server in a local environment.
 
 ## Vite configuration file
 

--- a/docs/guide/production.md
+++ b/docs/guide/production.md
@@ -15,6 +15,6 @@ You can change the build path in the [configuration](/guide/configuration), but 
 
 ## `ASSET_URL` environment variable
 
-Laravel's default `asset` helper makes use of the `ASSET_URL` environment variable to generate an asset link. This is particularly useful if assets are stored in a cloud-based storage such as S3, which is the case with [Laravel Vapor](https://docs.vapor.build/1.0/projects/deployments.html#assets).
+Both this package's [`vite_asset`](/guide/usage#assets) and Laravel's default `asset` helpers make use of the `ASSET_URL` environment variable to generate an asset link.
 
-The Vite NPM helper takes the `ASSET_URL` environment variable into account and injects it in Vite's `base` configuration option in order to properly link the assets in production.
+This is particularly useful if assets are stored in a cloud-based storage such as S3, which is the case with [Laravel Vapor](https://docs.vapor.build/1.0/projects/deployments.html#assets).

--- a/docs/guide/usage.md
+++ b/docs/guide/usage.md
@@ -106,7 +106,7 @@ Additionally, you can manually generate or update this file with the `vite:alias
 php artisan vite:aliases
 ```
 
-## Assets
+## Static assets
 
 Files stored in `resources/static` are served by Vite as if they were in the `public` directory. You can generate a path to an asset using `vite_asset()`. For instance, assuming you have a `cat.png` file in `resources/static/images`:
 
@@ -120,10 +120,10 @@ In production:
 -->
 ```
 
-:::warning
-This works well when using Blade, but **there is currently an unsolved issue when referencing assets in files processed by Vite**, such as a Vue or CSS file. In development, URLs will not be properly rewritten.
-
-That issue is tracked here: https://github.com/vitejs/vite/issues/2196.
-:::
-
 If you want to use a directory other than `resources/static`, you can change the [`public_directory` option](/guide/configuration#public-directory).
+
+## Vite-processed assets
+
+There is currently [an unsolved issue when referencing assets in files processed by Vite](https://github.com/vitejs/vite/issues/2196), such as a Vue or CSS file. **In development, URLs will not be properly rewritten**.
+
+Additionally, there is currently no way to get the path of a Vite-processed asset (eg. an image that was imported in a Vue SFC) from the back-end, since the manifest does not reference the original file path. In most cases, this should not be an issue, as this is not a common use case.

--- a/docs/guide/usage.md
+++ b/docs/guide/usage.md
@@ -41,11 +41,11 @@ Laravel Vite includes a few directives that handles linking assets in developmen
 	<title>Laravel</title>
 	@vite
 	<!--
-  In development:
-    <script type="module" src="http://localhost:3000/@vite/client"></script>
-    <script type="module" src="http://localhost:3000/resources/scripts/app.ts"></script>
-  In production:
-    <script type="module" src="http://laravel.local/build/assets/app.66e83946.js"></script>
+	In development:
+		<script type="module" src="http://localhost:3000/@vite/client"></script>
+		<script type="module" src="http://localhost:3000/resources/scripts/app.ts"></script>
+	In production:
+		<script type="module" src="http://laravel.local/build/assets/app.66e83946.js"></script>
 	-->
 </head>
 ```
@@ -63,13 +63,13 @@ Laravel Vite includes a few directives that handles linking assets in developmen
 	@vite('main')
 	@vite('resources/js/some-script.js')
 	<!-- 
-  In development:
-    <script type="module" src="http://localhost:3000/@vite/client"></script>
-    <script type="module" src="http://localhost:3000/resources/scripts/main.ts"></script>
-    <script type="module" src="http://localhost:3000/resources/js/some-script.js"></script>
-  In production:
-    <script type="module" src="http://laravel.local/build/assets/main.66e83946.js"></script>
-    <script type="module" src="http://laravel.local/build/assets/some-script.6d3515d2.js"></script>
+	In development:
+		<script type="module" src="http://localhost:3000/@vite/client"></script>
+		<script type="module" src="http://localhost:3000/resources/scripts/main.ts"></script>
+		<script type="module" src="http://localhost:3000/resources/js/some-script.js"></script>
+	In production:
+		<script type="module" src="http://laravel.local/build/assets/main.66e83946.js"></script>
+		<script type="module" src="http://laravel.local/build/assets/some-script.6d3515d2.js"></script>
 	-->
 </head>
 ```
@@ -105,3 +105,25 @@ Additionally, you can manually generate or update this file with the `vite:alias
 ```bash
 php artisan vite:aliases
 ```
+
+## Assets
+
+Files stored in `resources/static` are served by Vite as if they were in the `public` directory. You can generate a path to an asset using `vite_asset()`. For instance, assuming you have a `cat.png` file in `resources/static/images`:
+
+```html
+<img src="{{ vite_asset('images/cat.png') }}" alt="A cute cat" />
+<!-- 
+In development:
+	<img src="http://localhost:3000/images/cat.png" alt="A cute cat" />
+In production:
+	<img src="https://your-site.dev/build/images/cat.png " alt="A cute cat" />
+-->
+```
+
+:::warning
+This works well when using Blade, but **there is currently an unsolved issue when referencing assets in files processed by Vite**, such as a Vue or CSS file. In development, URLs will not be properly rewritten.
+
+That issue is tracked here: https://github.com/vitejs/vite/issues/2196.
+:::
+
+If you want to use a directory other than `resources/static`, you can change the [`public_directory` option](/guide/configuration#public-directory).

--- a/npm/package.json
+++ b/npm/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "laravel-vite",
-	"version": "0.0.5",
+	"version": "0.0.6",
 	"author": "Enzo Innocenzi",
 	"license": "MIT",
 	"main": "dist/index.js",

--- a/npm/package.json
+++ b/npm/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "laravel-vite",
-	"version": "0.0.4",
+	"version": "0.0.5",
 	"author": "Enzo Innocenzi",
 	"license": "MIT",
 	"main": "dist/index.js",

--- a/npm/package.json
+++ b/npm/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "laravel-vite",
-	"version": "0.0.6",
+	"version": "0.0.7",
 	"author": "Enzo Innocenzi",
 	"license": "MIT",
 	"main": "dist/index.js",

--- a/npm/src/index.ts
+++ b/npm/src/index.ts
@@ -44,13 +44,18 @@ export class ViteConfiguration {
 		dotenv.config()
 
 		// Sets the base directory.
-		this.base = process.env.ASSET_URL ?? '/'
+		this.base = process.env.ASSET_URL ?? ''
+
+		// Makes sure the base ends with a slash.
+		if (!this.base.endsWith('/'))
+			this.base += '/'
 
 		// In production, we want to append the build_path. It is not needed in development,
 		// since assets are served from the development server's root, but we're writing
 		// generated assets in public/build_path, so build_path needs to be referenced.
 		if (process.env.NODE_ENV?.startsWith('prod') || process.env.APP_ENV !== 'local') {
 			this.base += artisan.build_path ?? ''
+
 			if (!this.base.endsWith('/'))
 				this.base += '/'
 		}

--- a/npm/src/index.ts
+++ b/npm/src/index.ts
@@ -42,7 +42,19 @@ export class ViteConfiguration {
 
 	constructor(config: UserConfig = {}, artisan: PhpConfiguration = {}) {
 		dotenv.config()
+
+		// Sets the base directory.
 		this.base = process.env.ASSET_URL ?? '/'
+
+		// In production, we want to append the build_path. It is not needed in development,
+		// since assets are served from the development server's root, but we're writing
+		// generated assets in public/build_path, so build_path needs to be referenced.
+		if (process.env.NODE_ENV?.startsWith('prod') || process.env.APP_ENV !== 'local') {
+			this.base += artisan.build_path ?? ''
+			if (!this.base.endsWith('/'))
+				this.base += '/'
+		}
+
 		this.publicDir = artisan.public_directory ?? 'resources/static'
 		this.build = {
 			manifest: true,

--- a/npm/src/index.ts
+++ b/npm/src/index.ts
@@ -12,6 +12,7 @@ interface PhpConfiguration {
 	dev_url?: string
 	entrypoints?: false | string | string[]
 	aliases?: Record<string, string>
+	public_directory?: string
 }
 
 /**
@@ -42,7 +43,7 @@ export class ViteConfiguration {
 	constructor(config: UserConfig = {}, artisan: PhpConfiguration = {}) {
 		dotenv.config()
 		this.base = process.env.ASSET_URL ?? '/'
-		this.publicDir = 'resources/static'
+		this.publicDir = artisan.public_directory ?? 'resources/static'
 		this.build = {
 			manifest: true,
 			outDir: artisan?.build_path

--- a/src/Vite.php
+++ b/src/Vite.php
@@ -162,6 +162,9 @@ class Vite
         return false;
     }
 
+    /**
+     * Creates the script tag for including the development server.
+     */
     protected function createDevelopmentScriptTag(string $path): Htmlable
     {
         // I suspect ASSET_URL should be takin into account here.
@@ -171,5 +174,17 @@ class Vite
             Str::finish(\config('vite.dev_url'), '/'),
             $path
         ));
+    }
+
+    /**
+     * Gets a valid URL for the given asset. During development, the returned URL will be relative to the development server.
+     */
+    public function getAssetUrl(string $path): string
+    {
+        if ($this->shouldUseManifest()) {
+            return asset(sprintf('/%s/%s', config('vite.build_path'), $path));
+        }
+
+        return sprintf('%s/%s', config('vite.dev_url'), $path);
     }
 }

--- a/src/helpers.php
+++ b/src/helpers.php
@@ -47,3 +47,13 @@ if (! function_exists('vite_tags')) {
         return app()->make(Innocenzi\Vite\Vite::class)->getClientAndEntrypointTags();
     }
 }
+
+if (! function_exists('vite_asset')) {
+    /**
+     * Gets a valid URL for the given asset.
+     */
+    function vite_asset(string $path)
+    {
+        return app()->make(Innocenzi\Vite\Vite::class)->getAssetUrl($path);
+    }
+}

--- a/tests/Unit/DevelopmentServerTest.php
+++ b/tests/Unit/DevelopmentServerTest.php
@@ -15,3 +15,13 @@ it('does not use the development server if it is not started in a local environm
     Http::fake(fn () => Http::response(null, 404));
     get_vite('unknown-manifest.json')->getClientAndEntrypointTags();
 })->throws(ManifestNotFound::class, 'The manifest could not be found. Did you start the development server?');
+
+it('generates the right asset URL when the development server is running', function () {
+    Http::fake(fn () => Http::response());
+    expect(vite_asset('image.png'))->toBe('http://localhost:3000/image.png');
+});
+
+it('generates the right asset URL when the development server is not running', function () {
+    Http::fake(fn () => Http::response(null, 404));
+    expect(vite_asset('image.png'))->toBe('http://localhost/build/image.png');
+});

--- a/tests/Unit/ViteTest.php
+++ b/tests/Unit/ViteTest.php
@@ -109,3 +109,13 @@ it('generates production URLs that take the ASSET_URL environment variable into 
     expect(get_vite()->getClientAndEntrypointTags())
         ->toEqual('<script type="module" src="https://cdn.random.url/build/app.83b2e884.js"></script>');
 });
+
+it('generates an asset URL that takes ASSET_URL into account', function () {
+    app()->singleton('url', fn () => new UrlGenerator(
+        new RouteCollection(),
+        new Request(),
+        'https://cdn.random.url'
+    ));
+
+    expect(vite_asset('image.png'))->toBe('https://cdn.random.url/build/image.png');
+});


### PR DESCRIPTION
This PR adds a `vite_asset` helper which generates a proper URL for handling assets in Blade. 

However, assets in CSS or other Vite-handled files (such as Vue SFCs) will not properly be handled because Vite doesn't allow it yet. 

Related: https://github.com/vitejs/vite/issues/2196