### PR TITLE
Use `public/` for outDir by default

### DIFF
--- a/npm/src/index.ts
+++ b/npm/src/index.ts
@@ -63,9 +63,10 @@ export class ViteConfiguration {
 		this.publicDir = artisan.public_directory ?? 'resources/static'
 		this.build = {
 			manifest: true,
+			emptyOutDir: false,
 			outDir: artisan?.build_path
 				? `public/${artisan.build_path}`
-				: 'public/build',
+				: 'public',
 			rollupOptions: {
 				input: [],
 			},


### PR DESCRIPTION
This is more similar to what Laravel Mix does. By setting `emptyOutDir = false`, the build dir is no longer cleared by Vite.

Also I've ran into problems with `public/build/assets` because some Vite plugins assume that files in `outDir/assets` are served from the `/assets` route.