### PR TITLE
fix: add `baseUrl` to `tsconfig.json`

### DIFF
--- a/src/Commands/GenerateAliasesCommand.php
+++ b/src/Commands/GenerateAliasesCommand.php
@@ -38,7 +38,6 @@ class GenerateAliasesCommand extends Command
                 'esModuleInterop' => true,
                 'lib' => ['esnext', 'dom'],
                 'types' => ['vite/client'],
-                'baseUrl' => '.',
             ],
             'include' => ['resources/**/*'],
         ], JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES));
@@ -47,6 +46,7 @@ class GenerateAliasesCommand extends Command
     protected function writeAliases(): void
     {
         $tsconfig = json_decode(File::get($this->getTsConfigPath()), true);
+        $tsconfig['compilerOptions']['baseUrl'] = '.';
         $tsconfig['compilerOptions']['paths'] = collect(\config('vite.aliases'))
             ->mapWithKeys(fn ($value, $key) => ["${key}/*" => ["${value}/*"]])
             ->toArray();

--- a/src/Commands/GenerateAliasesCommand.php
+++ b/src/Commands/GenerateAliasesCommand.php
@@ -49,6 +49,7 @@ class GenerateAliasesCommand extends Command
         $tsconfig['compilerOptions']['baseUrl'] = '.';
         $tsconfig['compilerOptions']['paths'] = collect(\config('vite.aliases'))
             ->mapWithKeys(fn ($value, $key) => ["${key}/*" => ["${value}/*"]])
+            ->mergeRecursive($tsconfig['compilerOptions']['paths'] ?? [])
             ->toArray();
 
         File::put($this->getTsConfigPath(), \json_encode($tsconfig, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES));

--- a/src/Commands/GenerateAliasesCommand.php
+++ b/src/Commands/GenerateAliasesCommand.php
@@ -49,7 +49,7 @@ class GenerateAliasesCommand extends Command
         $tsconfig['compilerOptions']['baseUrl'] = '.';
         $tsconfig['compilerOptions']['paths'] = collect(\config('vite.aliases'))
             ->mapWithKeys(fn ($value, $key) => ["${key}/*" => ["${value}/*"]])
-            ->mergeRecursive($tsconfig['compilerOptions']['paths'] ?? [])
+            ->merge($tsconfig['compilerOptions']['paths'] ?? [])
             ->toArray();
 
         File::put($this->getTsConfigPath(), \json_encode($tsconfig, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES));

--- a/tests/Features/GenerateAliasesCommandTest.php
+++ b/tests/Features/GenerateAliasesCommandTest.php
@@ -36,3 +36,33 @@ it('does not create a tsconfig.json file if aliases are disabled', function () {
         expect(File::exists($tsconfigPath))->toBeFalse();
     });
 });
+
+it('merges path aliases with existing ones', function () {
+    sandbox(function () {
+        $tsconfigPath = base_path('tsconfig.json');
+
+        Config::set('vite.aliases', [
+            '@' => 'resources',
+            '@scripts' => 'resources/scripts',
+        ]);
+
+        File::put($tsconfigPath, \json_encode([
+            'compilerOptions' => [
+                'paths' => ['@test/*' => ['test/*']],
+            ],
+        ]));
+
+        test()->artisan('vite:aliases')->assertExitCode(0);
+        expect(File::exists($tsconfigPath))->toBeTrue();
+
+        expect(json_decode(File::get($tsconfigPath), true)['compilerOptions'])
+            ->toMatchArray([
+                'baseUrl' => '.',
+                'paths' => [
+                    '@/*' => ['resources/*'],
+                    '@scripts/*' => ['resources/scripts/*'],
+                    '@test/*' => ['test/*'],
+                ],
+            ]);
+    });
+});

--- a/tests/Features/GenerateAliasesCommandTest.php
+++ b/tests/Features/GenerateAliasesCommandTest.php
@@ -17,6 +17,7 @@ it('generates a tsconfig.json file with the updated aliases', function () {
 
         expect(json_decode(File::get($tsconfigPath), true)['compilerOptions'])
             ->toMatchArray([
+                'baseUrl' => '.',
                 'paths' => [
                     '@/*' => ['resources/*'],
                     '@scripts/*' => ['resources/scripts/*'],


### PR DESCRIPTION
`baseUrl` must always be set when `paths` is set (https://www.typescriptlang.org/tsconfig#paths).