### PR TITLE
feat: add artisan parameter to `defineConfig`

### DIFF
--- a/npm/src/index.ts
+++ b/npm/src/index.ts
@@ -246,8 +246,8 @@ export function createViteConfiguration() {
  *
  * @see https://github.com/innocenzi/laravel-vite
  */
-export function defineConfig(config: UserConfig = {}) {
-	const artisan = getConfigurationFromArtisan()
+export function defineConfig(config: UserConfig = {}, artisan?: PhpConfiguration) {
+	artisan = artisan ?? getConfigurationFromArtisan()
 	return new ViteConfiguration(config, artisan)
 }
 


### PR DESCRIPTION
In certain build environments you do php related build steps separate, and such
you might not have the ability to run php commands and node commands in the same build step.

We encountered this as we run the composer step in separate containers from node build step. This would let us run vite:config in a previous step then use that config later when we build javascript/css assets.