### PR TITLE
fix: change paths from ~/.valet to ~/.config/valet

### DIFF
--- a/npm/src/index.ts
+++ b/npm/src/index.ts
@@ -123,7 +123,7 @@ export class ViteConfiguration {
 			return this
 		}
 
-		return this.withCertificates(`${home}/.valet/Certificates/${domain}.key`, `${home}/.valet/Certificates/${domain}.crt`)
+		return this.withCertificates(`${home}/.config/valet/Certificates/${domain}.key`, `${home}/.config/valet/Certificates/${domain}.crt`)
 	}
 
 	/**


### PR DESCRIPTION
On recent versions of Laravel Valet, the config path is `~/.config/valet` ([Source](https://github.com/laravel/valet/commit/0fd37b0fed86389a23f97d43f3e2b03ccd9cbc3d))