### PR TITLE
fix: take dev_url config into account for react-refresh url

### DIFF
--- a/src/Vite.php
+++ b/src/Vite.php
@@ -53,10 +53,12 @@ class Vite
             return new HtmlString();
         }
 
+        $url = config('vite.dev_url');
+
         $script = <<<HTML
         <script type="module">
-            import RefreshRuntime from "http://localhost:3000/@react-refresh"
-            RefreshRuntime.injectIntoGlobalHook(window) 
+            import RefreshRuntime from "{$url}/@react-refresh"
+            RefreshRuntime.injectIntoGlobalHook(window)
             window.\$RefreshReg$ = () => {}
             window.\$RefreshSig$ = () => (type) => type
             window.__vite_plugin_react_preamble_installed__ = true


### PR DESCRIPTION
Currently the URL for `react-refresh` is hardcoded so it fails whenever you change the `dev_url` to anything else than the default value (`http://localhost:3000`). This PR fixes that.