### PR TITLE
Improved Lumen compatibility by registering Blade directives after resolving its compiler

### DIFF
--- a/src/ViteServiceProvider.php
+++ b/src/ViteServiceProvider.php
@@ -19,24 +19,26 @@ class ViteServiceProvider extends PackageServiceProvider
             ->hasCommand(GenerateAliasesCommand::class);
     }
 
-    public function registeringPackage()
+    public function bootingPackage()
     {
         $this->app->singleton(Vite::class, fn () => new Vite());
 
-        Blade::directive('vite', function ($entryName = null) {
-            if (! $entryName) {
-                return '<?php echo vite_tags() ?>';
-            }
+        $this->app->afterResolving('blade.compiler', function (BladeCompiler $compiler) {
+            $compiler->directive('vite', function ($entryName = null) {
+                if (! $entryName) {
+                    return '<?php echo vite_tags() ?>';
+                }
 
-            return sprintf('<?php echo vite_entry(e(%s)); ?>', $entryName);
-        });
+                return sprintf('<?php echo vite_entry(e(%s)); ?>', $entryName);
+            });
 
-        Blade::directive('client', function () {
-            return '<?php echo vite_client(); ?>';
-        });
+            $compiler->directive('client', function () {
+                return '<?php echo vite_client(); ?>';
+            });
 
-        Blade::directive('react', function () {
-            return '<?php echo vite_react_refresh_runtime(); ?>';
+            $compiler->directive('react', function () {
+                return '<?php echo vite_react_refresh_runtime(); ?>';
+            });
         });
     }
 }


### PR DESCRIPTION
I tried the package with Lumen and after configuring everything, I got this error:

> Target class [blade.compiler] does not exist.

By googling, I found a link to [this PR](https://github.com/laravel/framework/pull/25497) on laravel/framework and looking to the last [commit](https://github.com/jerodev/laravel-font-awesome/commit/3f72988c337c78eed69e1bf6b790fca86e49b0e2) and tried to include the `$this-app->afterResolving()` approach, that worked.

By the same googling session, I found a lot of suggestions about the use of `ServiceProvider::boot()` instead of `ServiceProvider::register()` when declaring singletons and Blade directives, so I moved replaced the `registeringPackage()` method with  `bootingPackage()`.