### PR TITLE
refactor: use `registeringPackage` instead of `bootingPackage` with `afterResolving`

### DIFF
--- a/src/ViteServiceProvider.php
+++ b/src/ViteServiceProvider.php
@@ -2,6 +2,7 @@
 
 namespace Innocenzi\Vite;
 
+use Illuminate\View\Compilers\BladeCompiler;
 use Innocenzi\Vite\Commands\ExportConfigurationCommand;
 use Innocenzi\Vite\Commands\GenerateAliasesCommand;
 use Spatie\LaravelPackageTools\Package;
@@ -22,7 +23,7 @@ class ViteServiceProvider extends PackageServiceProvider
     {
         $this->app->singleton(Vite::class, fn () => new Vite());
 
-        $this->app->afterResolving('blade.compiler', function ($compiler) {
+        $this->app->afterResolving('blade.compiler', function (BladeCompiler $compiler) {
             $compiler->directive('vite', function ($entryName = null) {
                 if (! $entryName) {
                     return '<?php echo vite_tags() ?>';

--- a/src/ViteServiceProvider.php
+++ b/src/ViteServiceProvider.php
@@ -2,7 +2,6 @@
 
 namespace Innocenzi\Vite;
 
-use Illuminate\Support\Facades\Blade;
 use Innocenzi\Vite\Commands\ExportConfigurationCommand;
 use Innocenzi\Vite\Commands\GenerateAliasesCommand;
 use Spatie\LaravelPackageTools\Package;
@@ -23,7 +22,7 @@ class ViteServiceProvider extends PackageServiceProvider
     {
         $this->app->singleton(Vite::class, fn () => new Vite());
 
-        $this->app->afterResolving('blade.compiler', function (BladeCompiler $compiler) {
+        $this->app->afterResolving('blade.compiler', function ($compiler) {
             $compiler->directive('vite', function ($entryName = null) {
                 if (! $entryName) {
                     return '<?php echo vite_tags() ?>';

--- a/src/ViteServiceProvider.php
+++ b/src/ViteServiceProvider.php
@@ -19,7 +19,7 @@ class ViteServiceProvider extends PackageServiceProvider
             ->hasCommand(GenerateAliasesCommand::class);
     }
 
-    public function bootingPackage()
+    public function registeringPackage()
     {
         $this->app->singleton(Vite::class, fn () => new Vite());
 

--- a/src/ViteServiceProvider.php
+++ b/src/ViteServiceProvider.php
@@ -19,24 +19,26 @@ class ViteServiceProvider extends PackageServiceProvider
             ->hasCommand(GenerateAliasesCommand::class);
     }
 
-    public function registeringPackage()
+    public function bootingPackage()
     {
         $this->app->singleton(Vite::class, fn () => new Vite());
 
-        Blade::directive('vite', function ($entryName = null) {
-            if (! $entryName) {
-                return '<?php echo vite_tags() ?>';
-            }
+        $this->app->afterResolving('blade.compiler', function (BladeCompiler $compiler) {
+            $compiler->directive('vite', function ($entryName = null) {
+                if (! $entryName) {
+                    return '<?php echo vite_tags() ?>';
+                }
 
-            return sprintf('<?php echo vite_entry(e(%s)); ?>', $entryName);
-        });
+                return sprintf('<?php echo vite_entry(e(%s)); ?>', $entryName);
+            });
 
-        Blade::directive('client', function () {
-            return '<?php echo vite_client(); ?>';
-        });
+            $compiler->directive('client', function () {
+                return '<?php echo vite_client(); ?>';
+            });
 
-        Blade::directive('react', function () {
-            return '<?php echo vite_react_refresh_runtime(); ?>';
+            $compiler->directive('react', function () {
+                return '<?php echo vite_react_refresh_runtime(); ?>';
+            });
         });
     }
 }


### PR DESCRIPTION
Sorry, but I faced no problems on running a Laravel project with `ViteServiceProvider::bootingPackage()` neither with `ViteServiceProvider::registeringPackage()` (as stated in issue #108), but I still pushed the fix to ensure compatibility with `Facade\Ignition\IgnitionServiceProvider::registerViewEngines()`.

If viable, I would like to ask @callmez if they could test my fix on their project by temporary referencing on my fork branch.

I keep staying in total disposition on helping with this PR.