### PR TITLE
feat: `withoutManifest` testing helper

### DIFF
--- a/src/Vite.php
+++ b/src/Vite.php
@@ -16,6 +16,7 @@ class Vite
     protected ?Manifest $manifest;
     protected ?string $manifestPath;
     protected ?bool $isDevelopmentServerRunning;
+    protected static ?bool $withoutManifest = false;
 
     /**
      * Creates a new Vite instance.
@@ -23,6 +24,22 @@ class Vite
     public function __construct(string $manifestPath = null)
     {
         $this->manifestPath = $manifestPath;
+    }
+
+    /**
+     * Configures Vite to not use the manifest.
+     */
+    public static function withoutManifest(): void
+    {
+        Vite::$withoutManifest = true;
+    }
+
+    /**
+     * Configures Vite to automatically determine if the manifest should be used.
+     */
+    public static function withManifest(): void
+    {
+        Vite::$withoutManifest = false;
     }
 
     /**
@@ -154,6 +171,10 @@ class Vite
      */
     protected function shouldUseManifest(): bool
     {
+        if (Vite::$withoutManifest === true) {
+            return false;
+        }
+
         if (! App::environment('local')) {
             return true;
         }

--- a/tests/Unit/ViteTest.php
+++ b/tests/Unit/ViteTest.php
@@ -6,6 +6,7 @@ use Illuminate\Routing\UrlGenerator;
 use Illuminate\Support\Facades\App;
 use Illuminate\Support\Facades\Config;
 use Innocenzi\Vite\Exceptions\NoSuchEntrypointException;
+use Innocenzi\Vite\Vite;
 
 beforeEach(fn () => start_dev_server());
 afterEach(fn () => stop_dev_server());
@@ -118,4 +119,11 @@ it('generates an asset URL that takes ASSET_URL into account', function () {
     ));
 
     expect(vite_asset('image.png'))->toBe('https://cdn.random.url/build/image.png');
+});
+
+it('does not throw when there is no manifest but withoutManifest was called', function () {
+    Vite::withoutManifest();
+    set_env('testing');
+    expect(get_vite('unknown-manifest.json')->getClientAndEntrypointTags())
+        ->toEqual('<script type="module" src="http://localhost:3000/@vite/client"></script>');
 });


### PR DESCRIPTION
Usage:

```php
test('login screen can be rendered', function () {
    Vite::withoutManifest();

    this()
        ->get('/login')
        ->assertStatus(Response::HTTP_OK);
});
```

Fixes #123