### PR TITLE
fix: remove hmr port

### DIFF
--- a/npm/src/index.ts
+++ b/npm/src/index.ts
@@ -129,7 +129,6 @@ export class ViteConfiguration {
 				port: port ? Number(port) : 3000,
 				hmr: {
 					host: host.substr(2),
-					port: Number(port) || 3000,
 				},
 			}
 


### PR DESCRIPTION
If the `hmr` endpoint uses the same port, we cannot use the Vite server in SSR middleware mode because the port is already blocked.

```js
  const vite = await createServer({
    server: { middlewareMode: 'ssr' }
  })
```