### PR TITLE
fix: allow passing no arguments to `.withValetCertificates()`

### DIFF
--- a/npm/src/index.ts
+++ b/npm/src/index.ts
@@ -170,10 +170,10 @@ export class ViteConfiguration {
 	/**
 	 * Configures the development server to use Valet's SSL certificates.
 	 */
-	public withValetCertificates({ domain, path }: { domain?: string; path?: string }): this {
+	public withValetCertificates(options?: { domain?: string; path?: string }): this {
 		const home = homedir()
-		path ??= '/.config/valet/Certificates/'
-		domain ??= process.env.APP_URL?.replace(/^https?:\/\//, '')
+		let path = options?.path ?? '/.config/valet/Certificates/'
+		let domain = options?.domain ?? process.env.APP_URL?.replace(/^https?:\/\//, '')
 
 		if (!domain) {
 			console.warn('No domain specified. Certificates will not be applied.')


### PR DESCRIPTION
Fixes #136. I tried a couple different things and this seemed like the cleanest—adding another method signature would have required both a `typeof ... === 'undefined'`, which is ugly, and also reassigning `path` and `domain` to new variables. This way the existing method signature doesn't actually change (I think?) and it's still quite readable.

[TypeScript playground.](https://www.typescriptlang.org/play?#code/JYWwDg9gTgLgBAbzgCwiApgE2FOBfOAMyjTgHIIBnMgKBvQA9JY4BjAGwENLK4A1YDHQBhCADtCwAOYBXKJxjBxiGnDhgZAI3bBWcAO6DkfTu3Qxh6WMEmsF6SgAoIYReMoB+AFyI4mNJzAYt5wlDBQQVIA3OoKyCFhEWJS+ACUPjDIwLwINACQrO7wqBhwALwoaFg4jqmqanBm8GBx5XAubmKeAHQtmXAeHuQA9N2FEtLDAG6m5sOW1rb2lMO0DY3mfgFBbR1KXR7d-iCBYgNDYCSsDpTd6GJT3QCCAAovAPoAqgBKADKHUHQYC410cwwAesgYDAwJ4vAAdYaI4YAGnIZFSajoeTyNjgjgAhMdTpjcjiCu4IGZuvpOFAxI4yAA5CBbE47ShgdCsGzALDdOALRRLIS8QzsdhwMQQeCadBwThgYF8zDdDHYnGAmByM6ZbL5PJ4DV4wl9ZB3MSYSgAdSMjNWqVJBryZraAAMACQIM14YZug1Gg1anVwPW3QyZIW8uyixyehAldB4L0+r3EoJ4boAa3QAE83Wj44nk964iX02JM6xYG66oa6GoNNpdAYjFGRQ5HDncz5EpE0ddYL3wpF0qGsjl6mpg-Tx-q1EbA44xOh9PxBCJxJJZPJOqkaUYTE127plrUojRl6v10JRBMdwp9vuI8ZZhYrMLT7GEHhUher2uAi3lu0hyI+4jPoeb4njGnZIBWPgyJa6CSCumBpP+K6ARud7bmBe4HpkR7mDBZ5IGaiHIahWAYZeWE3pu974U+hGvseH7RmRbKnD4ZCEBAEBkLRAEMbhoG7ixL7Ee+ixfnBsSZLxmh0kJv6YdeQGMXhEkQax0mkd+3FBJRmAoUEWBohR5DKVAql-nQImaWJD4EVJ0EcR2TjwdsYg+GIMgSsJ9FOSBLmSVB7GybBXkKcgPgAExBRpOGhcxuluZFn7RY4SAysgVi8foyAKHZURAA)

Like I said in the issue, I don't know TypeScript very well, so if there's a better way to do this that I'm missing I'm very open to feedback! Thanks.