### PR TITLE
feat: add Ignition solutions to exceptions

### DIFF
--- a/.php-cs-fixer.php
+++ b/.php-cs-fixer.php
@@ -13,6 +13,7 @@ $finder = Symfony\Component\Finder\Finder::create()
 return (new PhpCsFixer\Config())
     ->setRules([
         '@PSR2' => true,
+        'ternary_operator_spaces' => true,
         'array_syntax' => ['syntax' => 'short'],
         'ordered_imports' => ['sort_algorithm' => 'alpha'],
         'no_unused_imports' => true,
@@ -25,17 +26,16 @@ return (new PhpCsFixer\Config())
         'not_operator_with_successor_space' => true,
         'trailing_comma_in_multiline' => true,
         'phpdoc_scalar' => true,
-        'no_whitespace_in_blank_line' => true,
         'unary_operator_spaces' => true,
         'binary_operator_spaces' => true,
         'logical_operators' => true,
-        'array_indentation' => true,
         'blank_line_before_statement' => [
             'statements' => ['break', 'continue', 'declare', 'return', 'throw', 'try'],
         ],
         'phpdoc_single_line_var_spacing' => true,
         'phpdoc_var_without_name' => true,
         'method_chaining_indentation' => true,
+        'array_indentation' => true,
         'class_attributes_separation' => [
             'elements' => [
                 'method' => 'one',
@@ -53,6 +53,7 @@ return (new PhpCsFixer\Config())
         'no_singleline_whitespace_before_semicolons' => true,
         'trim_array_spaces' => true,
         'whitespace_after_comma_in_array' => true,
+        'single_blank_line_before_namespace' => true,
         'no_extra_blank_lines' => [
             'tokens' => [
                 'case',
@@ -68,8 +69,6 @@ return (new PhpCsFixer\Config())
                 'use_trait',
             ],
         ],
-        'single_quote' => true,
-        'escape_implicit_backslashes' => true,
         'native_constant_invocation' => [
             'include' => ['@compiler_optimized'],
             'strict' => true,

--- a/src/Exceptions/ManifestNotFound.php
+++ b/src/Exceptions/ManifestNotFound.php
@@ -2,16 +2,53 @@
 
 namespace Innocenzi\Vite\Exceptions;
 
+use Facade\IgnitionContracts\BaseSolution;
+use Facade\IgnitionContracts\ProvidesSolution;
+use Facade\IgnitionContracts\Solution;
 use Illuminate\Support\Facades\App;
+use Illuminate\Support\Facades\File;
 
-class ManifestNotFound extends \Exception
+class ManifestNotFound extends ViteException implements ProvidesSolution
 {
+    protected string $manifestPath;
+    protected array $links = [
+        'Using the development server' => 'https://laravel-vite.innocenzi.dev/guide/usage.html#development',
+        'Building the assets' => 'https://laravel-vite.innocenzi.dev/guide/production.html',
+    ];
+
     public function __construct(string $path)
     {
-        $hint = App::environment('local')
-            ? 'Did you start the development server?'
-            : 'Did you run the build command?';
+        $this->manifestPath = $path;
+        $this->message = sprintf('The manifest could not be found.');
+    }
 
-        $this->message = sprintf('The manifest could not be found. %s Tried: %s', $hint, $path);
+    public function getSolution(): Solution
+    {
+        $baseCommand = collect([
+            'pnpm-lock.yaml' => 'pnpm',
+            'yarn.lock' => 'yarn',
+        ])->reduce(function ($_, $command, $lockFile) {
+            if (File::exists(base_path($lockFile))) {
+                return $command;
+            }
+        }, 'npm run');
+
+        return App::environment('local')
+            ? $this->getLocalSolution($baseCommand)
+            : $this->getProductionSolution($baseCommand);
+    }
+
+    protected function getLocalSolution(string $baseCommand = 'npm run'): Solution
+    {
+        return BaseSolution::create('Start the development server')
+            ->setSolutionDescription("Run `${baseCommand} dev` in your terminal and refresh the page.")
+            ->setDocumentationLinks($this->links);
+    }
+
+    protected function getProductionSolution(string $baseCommand = 'npm run'): Solution
+    {
+        return BaseSolution::create('Build the production assets')
+            ->setSolutionDescription("Run `${baseCommand} build` in your terminal and refresh the page.")
+            ->setDocumentationLinks($this->links);
     }
 }

--- a/src/Exceptions/NoSuchEntrypointException.php
+++ b/src/Exceptions/NoSuchEntrypointException.php
@@ -2,10 +2,27 @@
 
 namespace Innocenzi\Vite\Exceptions;
 
-class NoSuchEntrypointException extends \Exception
+use Facade\IgnitionContracts\BaseSolution;
+use Facade\IgnitionContracts\ProvidesSolution;
+use Facade\IgnitionContracts\Solution;
+
+class NoSuchEntrypointException extends ViteException implements ProvidesSolution
 {
-    public function __construct(string $entry)
+    protected $entry;
+
+    public function __construct($entry)
     {
-        $this->message = "'${entry}' does not exist in the manifest. Make sure you added an entry point in the Vite configuration.";
+        $this->entry = (string) $entry;
+        $this->message = "Entry '{$this->entry}' does not exist in the manifest.";
+    }
+
+    public function getSolution(): Solution
+    {
+        return BaseSolution::create("Add it to your configuration")
+            ->setSolutionDescription('That entry point should be defined by the `vite.entrypoints` configuration option.')
+            ->setDocumentationLinks([
+                'About entrypoints' => 'https://laravel-vite.innocenzi.dev/guide/usage.html#entrypoints',
+                'Configuring entrypoints' => 'https://laravel-vite.innocenzi.dev/guide/configuration.html#options',
+            ]);
     }
 }

--- a/src/Exceptions/ViteException.php
+++ b/src/Exceptions/ViteException.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace Innocenzi\Vite\Exceptions;
+
+class ViteException extends \Exception
+{
+}

--- a/tests/Unit/DevelopmentServerTest.php
+++ b/tests/Unit/DevelopmentServerTest.php
@@ -13,7 +13,7 @@ it('uses the development server if it is started in a local environment', functi
 
 it('does not use the development server if it is not started in a local environment', function () {
     get_vite('unknown-manifest.json')->getClientAndEntrypointTags();
-})->throws(ManifestNotFound::class, 'The manifest could not be found. Did you start the development server?');
+})->throws(ManifestNotFound::class);
 
 it('generates the right asset URL when the development server is running', function () {
     with_dev_server(function () {


### PR DESCRIPTION
This PR adds Ignition solutions to the two exceptions that can be thrown by Laravel Vite.

![image](https://user-images.githubusercontent.com/16060559/136181643-f0478e17-cdc6-4253-82aa-c0b0bc9b5d65.png)