### PR TITLE
fix: support environment variable expansion

### DIFF
--- a/npm/package.json
+++ b/npm/package.json
@@ -37,6 +37,7 @@
     "debug": "^4.3.2",
     "deepmerge": "^4.2.2",
     "dotenv": "^10.0.0",
+		"dotenv-expand": "^5.1.0",
     "execa": "^5.1.1"
   }
 }

--- a/npm/src/index.ts
+++ b/npm/src/index.ts
@@ -6,6 +6,7 @@ import deepmerge from 'deepmerge'
 import execa from 'execa'
 import chalk from 'chalk'
 import dotenv from 'dotenv'
+import dotenvExpand from 'dotenv-expand'
 import makeDebugger from 'debug'
 
 type VitePlugin = Plugin | ((...params: any[]) => Plugin)
@@ -67,7 +68,7 @@ export class ViteConfiguration {
 		config: (UserConfig | ((env: typeof process.env) => UserConfig)) = {},
 		artisan: PhpConfiguration = {},
 	) {
-		dotenv.config()
+		dotenvExpand(dotenv.config())
 		debug('Loaded configuration with dotenv')
 
 		// Sets the base directory.


### PR DESCRIPTION
This fixes an issue where the usage of dotenv sets unexpanded VITE_* environment variables in the process.env which end up being prioritized [here](https://github.com/vitejs/vite/blob/10694dd6ad98933b7d857919c09c0f5f8c22da21/packages/vite/src/node/config.ts#L1001) and are therefore skipped [here](https://github.com/vitejs/vite/blob/10694dd6ad98933b7d857919c09c0f5f8c22da21/packages/vite/src/node/config.ts#L1025).

Given the example .env below, usages of `import.meta.env.VITE_APP_NAME` will now properly output `Laravel` instead of `${APP_NAME}`
```
APP_NAME=Laravel
VITE_APP_NAME=${APP_NAME}
```