### PR TITLE
fix(exceptions): return initial package manager command

### DIFF
--- a/src/Exceptions/ManifestNotFound.php
+++ b/src/Exceptions/ManifestNotFound.php
@@ -31,6 +31,7 @@ class ManifestNotFound extends ViteException implements ProvidesSolution
             if (File::exists(base_path($lockFile))) {
                 return $command;
             }
+            return $_;
         }, 'npm run');
 
         return App::environment('local')


### PR DESCRIPTION
Examples of this issue:

*   You use npm:
    *   Default value is first `npm ...`, then `null` and then `null`
*   You use pnpm:
    *   Default value is first `npm ...`, then `pnpm` and then `null`