### PR TITLE
feat: support non-script entrypoints via custom manifest

### DIFF
--- a/npm/src/index.ts
+++ b/npm/src/index.ts
@@ -8,6 +8,7 @@ import chalk from 'chalk'
 import dotenv from 'dotenv'
 import dotenvExpand from 'dotenv-expand'
 import makeDebugger from 'debug'
+import { manifestPlugin } from './manifest-plugin'
 
 type VitePlugin = Plugin | ((...params: any[]) => Plugin)
 interface PhpConfiguration {
@@ -109,6 +110,9 @@ export class ViteConfiguration {
 
 		// Adds the blade reload plugin.
 		this.plugins.push(bladeReload())
+
+		// Adds the manifest patch plugin.
+		this.plugins.push(manifestPlugin())
 
 		// Registers aliases.
 		if (artisan?.aliases) {

--- a/npm/src/manifest-plugin.ts
+++ b/npm/src/manifest-plugin.ts
@@ -1,0 +1,175 @@
+import { createHash } from 'crypto'
+import fs from 'fs/promises'
+import path from 'path'
+import { OutputAsset } from 'rollup'
+import { Manifest, ManifestChunk, Plugin, ResolvedConfig } from 'vite'
+
+// The concept of this plugin was taken from the Vite Ruby project.
+// See: https://github.com/ElMassimo/vite_ruby/blob/main/vite-plugin-ruby/src/manifest.ts
+// The main difference is that instead of writing a separate manifest,
+// this plugin merges its manifest with the one from Vite.
+
+/**
+ * Creates a plugin for patching Vite's manifest file.
+ * @see https://github.com/innocenzi/laravel-vite/issues/153
+ */
+export function manifestPlugin(): Plugin {
+	const manifest = new Map<string, ManifestChunk>()
+
+	let config: ResolvedConfig
+
+	return {
+		name: 'vite:laravel:manifest',
+		apply: 'build',
+		enforce: 'post',
+
+		configResolved(resolved) {
+			config = resolved
+		},
+
+		async generateBundle(_, bundle) {
+			const entrypoints = getEntrypoints(config)
+			if (!entrypoints) {
+				return
+			}
+
+			const values = Object.values(bundle)
+			const assets = values.filter((c) => c.type === 'asset') as OutputAsset[]
+
+			// -- CSS
+
+			const cssEntrypoints = entrypoints.filter((entry) => isStylesheet(entry))
+			const cssAssets = assets.filter((asset) => isStylesheet(asset.name!))
+
+			if (config.build.cssCodeSplit) {
+				// add CSS entrypoints to manifest
+				for (const chunk of cssAssets) {
+					if (!chunk.name) {
+						continue
+					}
+					const name = removeExtension(chunk.name!)
+					for (const entry of cssEntrypoints) {
+						if (removeExtension(path.basename(entry)) === name) {
+							manifest.set(entry, { file: chunk.fileName, src: entry, isEntry: true })
+						}
+					}
+				}
+			} else {
+				// Vite emits a single CSS file in this mode, named `style.css`
+				const chunk = assets.find((asset) => asset.name === 'style.css')
+				if (chunk) {
+					manifest.set(chunk.name!, { file: chunk.fileName, src: chunk.name! })
+				}
+			}
+
+			// -- Remaining Assets
+
+			const remaining = entrypoints.filter((entry) => isAssetEntrypoint(entry))
+
+			for (const entry of remaining) {
+				const fullPath = path.join(config.root, entry)
+				const source = await fs.readFile(fullPath)
+				const hash = getAssetHash(source)
+
+				const ext = path.extname(entry)
+				const name = removeExtension(entry)
+				const fileName = path.posix.join(
+					config.build.assetsDir,
+					`${path.basename(name)}.${hash}${ext}`,
+				)
+
+				manifest.set(entry, { file: fileName, src: entry, isEntry: true })
+
+				if (!bundle[fileName]) {
+					this.emitFile({ name: entry, fileName, source, type: 'asset' })
+				}
+			}
+		},
+
+		async writeBundle(_opts, bundle) {
+			if (!bundle['manifest.json']) {
+				return
+			}
+
+			// this is where the patching takes place,
+			// we find the manifest, read it, and then merge it with our own.
+			// once done, we write it back to disk
+
+			const manifestPath = path.resolve(config.root, config.build.outDir, 'manifest.json')
+			const viteManifest = JSON.parse(await fs.readFile(manifestPath, 'utf8')) as Manifest
+
+			for (const [key, value] of Object.entries(viteManifest)) {
+				manifest.set(key, value)
+			}
+
+			await fs.writeFile(
+				manifestPath,
+				JSON.stringify(Object.fromEntries(manifest), null, 2),
+			)
+		},
+	}
+}
+
+/**
+ * Gets the entrypoints from Rollup configuration.
+ * Entrypoints will be relative to the config root.
+ */
+function getEntrypoints(config: ResolvedConfig) {
+	let input = config.build.rollupOptions.input
+
+	if (!input) {
+		return null
+	}
+
+	if (typeof input === 'string') {
+		input = [input]
+	}
+
+	if (typeof input === 'object' && !Array.isArray(input)) {
+		const keys = Object.keys(input)
+		if (keys.length === 0) {
+			return null
+		}
+		input = keys
+	}
+
+	if (input.length === 0) {
+		return null
+	}
+
+	return input.map((entry) => path.relative(config.root, entry))
+}
+
+/**
+ * Removes the extension from a filename.
+ */
+function removeExtension(filename: string) {
+	return filename.replace(/\.[^.]*$/, '')
+}
+
+/**
+ * Determines if a filename is a stylesheet, e.g. `.css` or `.scss`.
+ */
+function isStylesheet(filename: string) {
+	return /\.(css|less|sass|scss|styl|stylus|pcss|postcss)$/.test(filename)
+}
+
+/**
+ * Determines if a filename is an asset entrypoint,
+ * which is an entrypoint otherwise not supported by Vite.
+ * This is pretty much non `html`, `js` and `css` files.
+ */
+function isAssetEntrypoint(filename: string) {
+	if (isStylesheet(filename)) {
+		return false
+	}
+
+	return !/\.(html|jsx?|tsx?)$/.test(filename)
+}
+
+/**
+ * Gets the asset hash for the contents of a file, the same way Vite does it.
+ */
+function getAssetHash(content: Buffer) {
+	return createHash('sha256').update(content).digest('hex').slice(0, 8)
+}

--- a/src/ManifestEntry.php
+++ b/src/ManifestEntry.php
@@ -4,6 +4,7 @@ namespace Innocenzi\Vite;
 
 use Illuminate\Contracts\Support\Htmlable;
 use Illuminate\Support\Collection;
+use Illuminate\Support\Str;
 use Stringable;
 
 class ManifestEntry implements Htmlable, Stringable
@@ -32,11 +33,15 @@ class ManifestEntry implements Htmlable, Stringable
     }
 
     /**
-     * Gets the script tag for this entry.
+     * Gets the tag for this entry.
      */
-    public function getScriptTag(): string
+    public function getTag(): string
     {
-        return sprintf('<script type="module" src="%s"></script>', $this->asset($this->file));
+        if (Str::endsWith($this->file, '.css')) {
+            return sprintf('<link rel="stylesheet" href="%s" />', $this->asset($this->file));
+        } else {
+            return sprintf('<script type="module" src="%s"></script>', $this->asset($this->file));
+        }
     }
 
     /**
@@ -53,7 +58,7 @@ class ManifestEntry implements Htmlable, Stringable
     public function getTags(): Collection
     {
         return Collection::make()
-            ->push($this->getScriptTag())
+            ->push($this->getTag())
             ->merge($this->getStyleTags());
     }
 


### PR DESCRIPTION
Fixes #153

You'll have to double check my work here - I couldn't run stuff locally.

This PR adds a manifest patching plugin, see #153. The way this plugin works is taken from Vite Ruby. This fixes support for CSS entrypoints, as well as other entrypoints, although non-JS/CSS entrypoints aren't handled by the `ManifestEntry` class, although that could be added later.