### PR TITLE
feat: support guzzle 6

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
 		"php": "^7.4|^8.0",
 		"illuminate/contracts": "^8.0",
 		"spatie/laravel-package-tools": "^1.1",
-		"guzzlehttp/guzzle": "^7.2"
+		"guzzlehttp/guzzle": "^6.0|^7.2"
 	},
 	"require-dev": {
 		"friendsofphp/php-cs-fixer": "^3.2.1",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "ef36f9edadbdb207a63964cea6e5aaf3",
+    "content-hash": "e997abe0a4f1365345dd05dc720589e3",
     "packages": [
         {
             "name": "brick/math",


### PR DESCRIPTION
Laravel Vite works just fine with Guzzle 6. I'd like it to be allowed as my company is stuck with Guzzle 6 because of some other unmaintaned library.