### PR TITLE
feat!: do not use manifest in dev or test environments

### DIFF
--- a/src/Vite.php
+++ b/src/Vite.php
@@ -205,7 +205,7 @@ class Vite
             return false;
         }
 
-        if (App::environment('production')) {
+        if (! App::environment(['local', 'testing'])) {
             return true;
         }
 

--- a/src/Vite.php
+++ b/src/Vite.php
@@ -205,7 +205,7 @@ class Vite
             return false;
         }
 
-        if (! App::environment('local')) {
+        if (App::environment('production')) {
             return true;
         }
 

--- a/tests/Unit/ViteTest.php
+++ b/tests/Unit/ViteTest.php
@@ -125,6 +125,7 @@ it('generates production URLs that take the ASSET_URL environment variable into 
 
     Config::set('vite.entrypoints', 'scripts');
     App::setBasePath(__DIR__);
+    set_env('production');
     expect(get_vite()->getClientAndEntrypointTags())
         ->toEqual('<script type="module" src="https://cdn.random.url/build/app.83b2e884.js"></script>');
 });
@@ -136,6 +137,7 @@ it('generates an asset URL that takes ASSET_URL into account', function () {
         'https://cdn.random.url'
     ));
 
+    set_env('production');
     expect(vite_asset('image.png'))->toBe('https://cdn.random.url/build/image.png');
 });
 


### PR DESCRIPTION
The manifest should only be returned in production, so having to check if the enviroment is local falls short for when the enviroment is staging or testing. Wich would make more sense

Also see here: https://github.com/innocenzi/laravel-vite/pull/126#issuecomment-1000381350