### PR TITLE
fix: render css entrypoints as link tags in development

### DIFF
--- a/src/Vite.php
+++ b/src/Vite.php
@@ -241,6 +241,7 @@ class Vite
 
         return $this->isDevelopmentServerRunning = false;
     }
+
     /**
      * Creates the tag for including the development server.
      */

--- a/src/Vite.php
+++ b/src/Vite.php
@@ -126,7 +126,7 @@ class Vite
         }
 
         return $this->getEntries()->first(fn (Htmlable $entry) => Str::contains($entry->toHtml(), $name))
-            ?? $this->createDevelopmentScriptTag($name);
+            ?? $this->createDevelopmentTag($name);
     }
 
     /**
@@ -139,7 +139,7 @@ class Vite
         }
 
         return $this->findEntrypoints()
-            ->map(fn (\SplFileInfo $file) => $this->createDevelopmentScriptTag(
+            ->map(fn (\SplFileInfo $file) => $this->createDevelopmentTag(
                 Str::of($file->getPathname())
                     ->replace(base_path(), '')
                     ->replace('\\', '/')
@@ -240,6 +240,31 @@ class Vite
         }
 
         return $this->isDevelopmentServerRunning = false;
+    }
+    /**
+     * Creates the tag for including the development server.
+     */
+    protected function createDevelopmentTag(string $path): Htmlable
+    {
+        if (Str::endsWith($path, '.css')) {
+            return $this->createDevelopmentLinkTag($path);
+        }
+
+        return $this->createDevelopmentScriptTag($path);
+    }
+
+    /**
+     * Creates the link tag for including the development server.
+     */
+    protected function createDevelopmentLinkTag(string $path): Htmlable
+    {
+        // I suspect ASSET_URL should be takin into account here.
+        // If you find out it does, feel free to open an issue.
+        return new HtmlString(sprintf(
+            '<link rel="stylesheet" href="%s%s" />',
+            Str::finish(config('vite.dev_url'), '/'),
+            $path
+        ));
     }
 
     /**


### PR DESCRIPTION
As mentioned in https://github.com/innocenzi/laravel-vite/discussions/180.

This makes CSS entrypoints output as `link` tags in dev mode instead of `script` tags, preventing the CSS load delay and FOUC.