### PR TITLE
fix: trim leading slash when fetching entry from manifest

### DIFF
--- a/src/Manifest.php
+++ b/src/Manifest.php
@@ -42,7 +42,7 @@ class Manifest implements Htmlable, Stringable
      */
     public function getEntry(string $name): ManifestEntry
     {
-        if (! $entry = $this->entries->first(fn (ManifestEntry $entry) => Str::contains($entry->src, $name))) {
+        if (! $entry = $this->entries->first(fn (ManifestEntry $entry) => Str::contains($entry->src, ltrim($name, '/')))) {
             throw new NoSuchEntrypointException($name);
         }
 


### PR DESCRIPTION
When in development mode you can specify entrypoint paths with or without a leading slash, as `Vite::getEntries()` trims the slash.

```blade
// Both of these work
{{ vite_entry('/resources/scripts/app.js') }}
{{ vite_entry('resources/scripts/app.js') }}
```

However, when using the mainfest adding a leading slash fails with `Entry '/resources/scripts/app.js' does not exist in the manifest`.

This fixes that by trimming the slash before lookup.