### PR TITLE
fix: trim leading slash from `vite_asset` path

### DIFF
--- a/src/Vite.php
+++ b/src/Vite.php
@@ -288,9 +288,9 @@ class Vite
     public function getAssetUrl(string $path): string
     {
         if ($this->shouldUseManifest()) {
-            return asset(sprintf('/%s/%s', config('vite.build_path'), $path));
+            return asset(sprintf('/%s/%s', config('vite.build_path'), ltrim($path, '/')));
         }
 
-        return sprintf('%s/%s', config('vite.dev_url'), $path);
+        return sprintf('%s/%s', config('vite.dev_url'), ltrim($path, '/'));
     }
 }


### PR DESCRIPTION
Trim leading slash from paths passed to `vite_asset`.

Currently:

```php
vite_asset('test.svg'); // http://localhost:3000/test.svg
vite_asset('/test.svg'); // http://localhost:3000//test.svg
```

With change:

```php
vite_asset('test.svg'); // http://localhost:3000/test.svg
vite_asset('/test.svg'); // http://localhost:3000/test.svg
```

I'm not sure the double slash actually matters (the paths still work), but it looks tidier and Laravel's `asset` helper does the same thing.