### PR TITLE
Fix development server not working in Laravel 9.

### DIFF
--- a/src/HeartbeatCheckers/HttpHeartbeatChecker.php
+++ b/src/HeartbeatCheckers/HttpHeartbeatChecker.php
@@ -18,7 +18,7 @@ final class HttpHeartbeatChecker implements HeartbeatChecker
                 'verify' => false,
             ]);
 
-            if (Str::startsWith(app()->version(), '9')) {
+            if ((int) Str::substr(app()->version(), 0, 1) >= 9) {
                 $request->connectTimeout($timeout);
             }
 

--- a/src/HeartbeatCheckers/HttpHeartbeatChecker.php
+++ b/src/HeartbeatCheckers/HttpHeartbeatChecker.php
@@ -13,10 +13,16 @@ final class HttpHeartbeatChecker implements HeartbeatChecker
         try {
             $url = Str::of($url)->finish('/')->append(Vite::CLIENT_SCRIPT_PATH);
 
-            return Http::withOptions([
+            $request = Http::withOptions([
                 'connect_timeout' => $timeout,
                 'verify' => false,
-            ])->get($url)->successful();
+            ]);
+
+            if (Str::startsWith(app()->version(), '9')) {
+                $request->connectTimeout($timeout);
+            }
+
+            return $request->get($url)->successful();
         } catch (\Throwable) {
         }
 


### PR DESCRIPTION
Laravel 9 adds a default connection timeout to the Http client, making the usage of `connect_timeout` in `Http::withOptions` calls to cause an exception when the options reach guzzle.

This is due to `withOptions` using `array_merge_recursive` to merge the options, causing existing options to be arrayed.

This PR fixes it by using the `connectTimeout` method added in Laravel 9.