### PR TITLE
Support for running vitest as an end user

### DIFF
--- a/vite-plugin-laravel/src/utils.ts
+++ b/vite-plugin-laravel/src/utils.ts
@@ -56,8 +56,8 @@ export function findPhpPath(options: PhpFinderOptions = {}): string {
  * Calls an artisan command.
  */
 export function callArtisan(executable: string, ...params: string[]): string {
-	if (process.env.VITEST) {
-		return execaSync(process.env.TEST_ARTISAN_SCRIPT!, [executable, 'artisan', ...params], { encoding: 'utf-8' })?.stdout
+	if (process.env.VITEST && process.env.TEST_ARTISAN_SCRIPT) {
+		return execaSync(process.env.TEST_ARTISAN_SCRIPT, [executable, 'artisan', ...params], { encoding: 'utf-8' })?.stdout
 	}
 
 	return execaSync(executable, ['artisan', ...params])?.stdout
@@ -67,8 +67,8 @@ export function callArtisan(executable: string, ...params: string[]): string {
  * Calls a shell command.
  */
 export function callShell(executable: string, ...params: string[]): string {
-	if (process.env.VITEST) {
-		return execaSync(process.env.TEST_ARTISAN_SCRIPT!, [executable, ...params])?.stdout
+	if (process.env.VITEST && process.env.TEST_ARTISAN_SCRIPT) {
+		return execaSync(process.env.TEST_ARTISAN_SCRIPT, [executable, ...params])?.stdout
 	}
 
 	return execaSync(executable, [...params])?.stdout


### PR DESCRIPTION
Thanks for the great package, it helped me tons. I noticed that I couldn't run my own code against vitest with this plugin installed.

This is because the `readConfig` method uses `callArtisan`, and the `callArtisan` method checks if the env var `VITEST` is set. If it is, it will assume we are trying to run vitest against the laravel-vite code, and expects the `TEST_ARTISAN_SCRIPT` env var to exist.

When running vitest in my own Laravel project, the VITEST env var is automatically set, so this ran into an error (because TEST_ARTISAN_SCRIPT env var is not set).

This PR just makes sure that the TEST_ARTISAN_SCRIPT is set before executing the execaSync method against the TEST_ARTISAN_SCRIPT value.