### PR TITLE
Add CSS and modulepreload tags for imported chunks

### DIFF
--- a/src/TagGenerators/CallbackTagGenerator.php
+++ b/src/TagGenerators/CallbackTagGenerator.php
@@ -28,4 +28,13 @@ final class CallbackTagGenerator implements TagGenerator
 
         return $this->tagGenerator->makeStyleTag($url, $chunk);
     }
+
+    public function makePreloadTag(string $url, Chunk $chunk = null): string
+    {
+        if (\is_callable(Vite::$makePreloadTagsCallback)) {
+            return \call_user_func(Vite::$makePreloadTagsCallback, $url, $chunk);
+        }
+
+        return $this->tagGenerator->makePreloadTag($url, $chunk);
+    }
 }

--- a/src/TagGenerators/DefaultTagGenerator.php
+++ b/src/TagGenerators/DefaultTagGenerator.php
@@ -20,6 +20,11 @@ final class DefaultTagGenerator implements TagGenerator
         return sprintf('<link rel="stylesheet" href="%s"%s />', $url, $this->processIntegrity($chunk));
     }
 
+    public function makePreloadTag(string $url, Chunk $chunk = null): string
+    {
+        return sprintf('<link rel="modulepreload" href="%s"%s />', $url, $this->processIntegrity($chunk));
+    }
+
     protected function makeLegacyScriptTag(string $url, Chunk $chunk = null): string
     {
         if (str_contains($chunk?->src, 'vite/legacy-polyfills')) {

--- a/src/TagGenerators/TagGenerator.php
+++ b/src/TagGenerators/TagGenerator.php
@@ -9,4 +9,6 @@ interface TagGenerator
     public function makeScriptTag(string $url, Chunk $chunk = null): string;
 
     public function makeStyleTag(string $url, Chunk $chunk = null): string;
+
+    public function makePreloadTag(string $url, Chunk $chunk = null): string;
 }

--- a/src/Vite.php
+++ b/src/Vite.php
@@ -8,7 +8,7 @@ use Illuminate\Support\Traits\Macroable;
 final class Vite
 {
     use Macroable;
-    
+
     const CLIENT_SCRIPT_PATH = '@vite/client';
 
     protected array $configs = [];
@@ -17,11 +17,16 @@ final class Vite
      * @var (Closure(string, Innocenzi\Vite\Chunk|null): string)
      */
     public static Closure|null $makeScriptTagsCallback = null;
-    
+
     /**
      * @var (Closure(string, Innocenzi\Vite\Chunk|null): string)
      */
     public static Closure|null $makeStyleTagsCallback = null;
+
+    /**
+     * @var (Closure(string, Innocenzi\Vite\Chunk|null): string)
+     */
+    public static Closure|null $makePreloadTagsCallback = null;
 
     /**
      * @var (Closure(Innocenzi\Vite\Configuration): bool|null)
@@ -59,6 +64,16 @@ final class Vite
     }
 
     /**
+     * Sets the logic for creating a module preload tag.
+     *
+     * @param (Closure(string, Innocenzi\Vite\Chunk|null): string) $callback
+     */
+    public static function makePreloadTagsUsing(Closure $callback = null): void
+    {
+        static::$makePreloadTagsCallback = $callback;
+    }
+
+    /**
      * Sets the logic for determining if the manifest should be used.
      *
      * @param (Closure(Innocenzi\Vite\Configuration): bool|null) $callback
@@ -67,7 +82,7 @@ final class Vite
     {
         static::$useManifestCallback = $callback;
     }
-    
+
     /**
      * Execute a method against the default configuration.
      */

--- a/tests/Features/ManifestTest.php
+++ b/tests/Features/ManifestTest.php
@@ -11,7 +11,7 @@ it('guesses the configuration name from the manifest path', function () {
 
     expect(Manifest::guessConfigName(public_path('build/config-name/manifest.json')))
         ->toBe('config-name');
-        
+
     set_vite_config('default', [
         'build_path' => 'build',
     ]);
@@ -102,4 +102,20 @@ it('generates legacy and polyfill script tags', function () {
         ->toContain('<script nomodule src="http://localhost/legacy/assets/main-legacy.e72ecf9c.js"></script>')
         ->toContain('<script type="module" src="http://localhost/legacy/assets/main.eb449349.js"></script>')
         ->toContain('<script nomodule id="vite-legacy-polyfill"');
+});
+
+it('finds nested imports', function () {
+    set_fixtures_path('builds');
+    set_env('production');
+    set_vite_config('default', ['build_path' => 'with-nested-imports']);
+
+    expect(vite()->getTags())
+        ->toContain('<script type="module" src="http://localhost/with-nested-imports/A.js"></script>')
+        ->toContain('<link rel="stylesheet" href="http://localhost/with-nested-imports/A.css" />')
+        ->toContain('<link rel="modulepreload" href="http://localhost/with-nested-imports/B.js" />')
+        ->toContain('<link rel="stylesheet" href="http://localhost/with-nested-imports/B.css" />')
+        ->toContain('<link rel="modulepreload" href="http://localhost/with-nested-imports/C.js" />')
+        ->toContain('<link rel="stylesheet" href="http://localhost/with-nested-imports/C.css" />')
+        ->toContain('<link rel="modulepreload" href="http://localhost/with-nested-imports/D.js" />')
+        ->toContain('<link rel="stylesheet" href="http://localhost/with-nested-imports/D.css" />');
 });

--- a/tests/Features/TagGeneratorsTest.php
+++ b/tests/Features/TagGeneratorsTest.php
@@ -20,6 +20,11 @@ it('generates a style tag with the specified url', function () {
         ->toBe('<link rel="stylesheet" href="https://localhost/build/main.css" />');
 });
 
+it('generates a modulepreload tag with the specified url', function () {
+    expect(app(DefaultTagGenerator::class)->makePreloadTag('https://localhost/build/main.ts'))
+        ->toBe('<link rel="modulepreload" href="https://localhost/build/main.ts" />');
+});
+
 it('respects TagGenerator overrides in development', function () {
     app()->bind(TagGenerator::class, fn () => new CrossOriginTagGenerator());
 
@@ -31,7 +36,7 @@ it('respects TagGenerator overrides in development', function () {
             'paths' => 'entrypoints/multiple-with-css',
         ],
     ]);
-    
+
     expect(vite()->getTags())
         ->toContain('<script type="module" src="http://localhost:5173/@vite/client" crossorigin></script>')
         ->toContain('<script type="module" src="http://localhost:5173/entrypoints/multiple-with-css/main.ts" crossorigin></script>')
@@ -55,7 +60,7 @@ it('respects TagGenerator callback overrides in development', function () {
             'paths' => 'entrypoints/multiple-with-css',
         ],
     ]);
-    
+
     expect(vite()->getTags())
         ->toContain('<script type="module" src="http://localhost:5173/@vite/client" crossorigin="anonymous"></script>')
         ->toContain('<script type="module" src="http://localhost:5173/entrypoints/multiple-with-css/main.ts" crossorigin="anonymous"></script>')
@@ -70,16 +75,18 @@ it('respects TagGenerator overrides in production', function () {
 
     set_fixtures_path('builds');
     set_env('production');
-        
+
     expect(using_manifest('builds/public/with-css/manifest.json')->getTags())
         ->toContain('<link rel="stylesheet" href="http://localhost/with-css/assets/test.65bd481b.css" crossorigin />')
-        ->toContain('<script type="module" src="http://localhost/with-css/assets/test.a2c636dd.js" crossorigin></script>');
+        ->toContain('<script type="module" src="http://localhost/with-css/assets/test.a2c636dd.js" crossorigin></script>')
+        ->toContain('<link rel="stylesheet" href="http://localhost/with-css/assets/import.65bd481b.css" crossorigin />')
+        ->toContain('<link rel="modulepreload" href="http://localhost/with-css/assets/import.a1c332bb.js" crossorigin />');
 });
 
 it('uses integrity attributes when the chunk contains them', function () {
     set_fixtures_path('builds');
     set_env('production');
-        
+
     expect(using_manifest('builds/public/with-integrity/manifest.json')->getTags())
         ->toContain('<link rel="stylesheet" href="http://localhost/with-integrity/assets/main.65bd481b.css" />')
         ->toContain('<script type="module" src="http://localhost/with-integrity/assets/main.a2c636dd.js" integrity="sha384-2A5vUNf7cFDCWm6RTDPAnr/wmGjkQhXz4EP5keVPYX4OnI2Ws1iXgTQ70CTmC1Ux" crossorigin="anonymous"></script>')
@@ -96,5 +103,10 @@ class CrossOriginTagGenerator implements TagGenerator
     public function makeStyleTag(string $url, Chunk $chunk = null): string
     {
         return sprintf('<link rel="stylesheet" href="%s" crossorigin />', $url);
+    }
+
+    public function makePreloadTag(string $url, Chunk $chunk = null): string
+    {
+        return sprintf('<link rel="modulepreload" href="%s" crossorigin />', $url);
     }
 }

--- a/tests/Fixtures/builds/public/with-css/assets/import.65bd481b.css
+++ b/tests/Fixtures/builds/public/with-css/assets/import.65bd481b.css
@@ -1,0 +1,1 @@
+body{color:red}

--- a/tests/Fixtures/builds/public/with-css/assets/import.a1c332bb.js
+++ b/tests/Fixtures/builds/public/with-css/assets/import.a1c332bb.js
@@ -1,0 +1,1 @@
+console.log("test owo");

--- a/tests/Fixtures/builds/public/with-css/manifest.json
+++ b/tests/Fixtures/builds/public/with-css/manifest.json
@@ -3,8 +3,18 @@
     "file": "assets/test.a2c636dd.js",
     "src": "resources/scripts/test.ts",
     "isEntry": true,
+		"imports": [
+			"_import.a1c332bb.js"
+		],
     "css": [
       "assets/test.65bd481b.css"
     ]
-  }
+  },
+	"_import.a1c332bb.js": {
+		"file": "assets/import.a1c332bb.js",
+		"src": "resources/scripts/import.ts",
+		"css": [
+			"assets/import.65bd481b.css"
+		]
+	}
 }

--- a/tests/Fixtures/builds/public/with-nested-imports/manifest.json
+++ b/tests/Fixtures/builds/public/with-nested-imports/manifest.json
@@ -1,0 +1,26 @@
+{
+	"resources/scripts/A.ts": {
+		"file": "A.js",
+		"src": "resources/scripts/A.ts",
+		"isEntry": true,
+		"imports": ["B.js", "C.js"],
+		"css": ["A.css"]
+	},
+	"B.js": {
+		"file": "B.js",
+		"src": "resources/scripts/B.ts",
+		"imports": ["D.js"],
+		"css": ["B.css"]
+	},
+	"C.js": {
+		"file": "C.js",
+		"src": "resources/scripts/C.ts",
+		"imports": ["D.js"],
+		"css": ["C.css"]
+	},
+	"D.js": {
+		"file": "D.js",
+		"src": "resources/scripts/D.ts",
+		"css": ["D.css"]
+	}
+}


### PR DESCRIPTION
Closes #272
 
- Add a `makePreloadTag` method to the TagGenerator to generate
  modulepreload tags, and corresponding methods to configure it.
  Use this method when getting a chunk's tag if it's not an
  entrypoint.

- When getting a chunk's tags, append all the tags for its
  imported chunks too. Call `unique` on the collection to
  prevent duplicate tags, in case imports overlap.

- Output tags with a newline separator for better legibility.

- Add/update tests.

Note that I haven't built in any protection against circular references, though I suspect it's not possible to actually end up with a circular manifest structure unless you manually tamper with the manifest file.