### PR TITLE
feat: support generating custom manifest paths

### DIFF
--- a/src/Configuration.php
+++ b/src/Configuration.php
@@ -52,6 +52,16 @@ final class Configuration
      */
     public function getManifestPath(): string
     {
+        // If there is a strategy override, try to use that.
+        if (\is_callable(Vite::$findManifestPathWith)) {
+            $result = \call_user_func(Vite::$findManifestPathWith, $this);
+
+            // Only override if there is a result.
+            if (!\is_null($result)) {
+                return $result;
+            }
+        }
+
         return str_replace(
             ['\\', '//'],
             '/',

--- a/src/Vite.php
+++ b/src/Vite.php
@@ -34,6 +34,11 @@ final class Vite
     public static Closure|null $useManifestCallback = null;
 
     /**
+     * @var (Closure(Innocenzi\Vite\Configuration): bool|null)
+     */
+    public static Closure|null $findManifestPathWith = null;
+
+    /**
      * Gets the given configuration or the default one.
      */
     public function config(string $name = null): Configuration
@@ -81,6 +86,16 @@ final class Vite
     public static function useManifest(Closure $callback = null): void
     {
         static::$useManifestCallback = $callback;
+    }
+
+    /**
+     * Sets the logic for finding the manifest path.
+     *
+     * @param (Closure(Innocenzi\Vite\Configuration): bool|null) $callback
+     */
+    public static function findManifestPathWith(Closure $callback = null): void
+    {
+        static::$findManifestPathWith = $callback;
     }
 
     /**

--- a/tests/Features/ManifestTest.php
+++ b/tests/Features/ManifestTest.php
@@ -1,8 +1,10 @@
 <?php
 
+use Innocenzi\Vite\Configuration;
 use Innocenzi\Vite\Exceptions\ManifestNotFoundException;
 use Innocenzi\Vite\Exceptions\NoSuchEntrypointException;
 use Innocenzi\Vite\Manifest;
+use Innocenzi\Vite\Vite;
 
 it('guesses the configuration name from the manifest path', function () {
     set_vite_config('config-name', [
@@ -118,4 +120,16 @@ it('finds nested imports', function () {
         ->toContain('<link rel="stylesheet" href="http://localhost/with-nested-imports/C.css" />')
         ->toContain('<link rel="modulepreload" href="http://localhost/with-nested-imports/D.js" />')
         ->toContain('<link rel="stylesheet" href="http://localhost/with-nested-imports/D.css" />');
+});
+
+it('can override the manifest path name generation', function () {
+    set_fixtures_path('builds');
+    set_env('production');
+
+    Vite::findManifestPathWith(function (Configuration $configuration) {
+        return $configuration->getConfig('build_path') . '/owo/manifest.json';
+    });
+
+    set_vite_config('default', ['build_path' => '/build']);
+    expect(vite()->getManifestPath())->toBe('/build/owo/manifest.json');
 });


### PR DESCRIPTION
This PR introduces a way of customizing the logic to find the path to a manifest file.

```php
Vite::findManifestPathWith(function (Configuration $configuration) {
    // Custom manifest path generation logic
    $buildPath = $configuration->getConfig('build_path');

    return base_path($buildPath . '/public_html/manifest.json'); // adapt for your needs
});
```

Closes https://github.com/innocenzi/laravel-vite/issues/296