### PR TITLE
docs: update statement about CSS pre-processors

### DIFF
--- a/docs/src/guide/quick-start.md
+++ b/docs/src/guide/quick-start.md
@@ -87,7 +87,7 @@ The main configuration is defined in `config/vite.php`, which the Vite plugin re
 
 If you were using any Webpack loader for TypeScript, Vue, PostCSS, SASS, Stylus... you can safely remove them. Vite handles them without additional configuration. 
 
-You can learn more about this on the [Vite documentation](https://vitejs.dev/guide/features.html#css-pre-processors).
+Except for PostCSS, you do need to install the CSS pre-processors you are using, though. You can learn more about this on the [Vite documentation](https://vitejs.dev/guide/features.html#css-pre-processors).
 
 #### Input files
 

--- a/docs/src/guide/quick-start.md
+++ b/docs/src/guide/quick-start.md
@@ -87,7 +87,7 @@ The main configuration is defined in `config/vite.php`, which the Vite plugin re
 
 If you were using any Webpack loader for TypeScript, Vue, PostCSS, SASS, Stylus... you can safely remove them. Vite handles them without additional configuration. 
 
-You do need to install the CSS pre-processors you are using, though. You can learn more about this on the [Vite documentation](https://vitejs.dev/guide/features.html#css-pre-processors).
+You can learn more about this on the [Vite documentation](https://vitejs.dev/guide/features.html#css-pre-processors).
 
 #### Input files
 


### PR DESCRIPTION
The docs currently say "You do need to install the CSS pre-processors you are using, though". However, the page linked to [clearly states](https://vitejs.dev/guide/features.html#css) that the base package for a CSS pre-processor must be installed if not using postcss:

> There is no need to install Vite-specific plugins for them, ***but the corresponding pre-processor itself must be installed***