### PR TITLE
fix: improve regex expression to allow default vite config.ts

### DIFF
--- a/vite-plugin-laravel/src/config.ts
+++ b/vite-plugin-laravel/src/config.ts
@@ -234,7 +234,7 @@ function findConfigName(): string | undefined {
 		return
 	}
 
-	const fileNameRegex = /vite\.([\w-]+)\.config\.ts/
+	const fileNameRegex = /vite\.?([\w-]+)?\.config\.ts/
 	const configFile = process.argv.at(configIndex + 1)
 
 	return fileNameRegex.exec(configFile || '')?.at(1)?.trim()


### PR DESCRIPTION
Modify regex expression to allow for both 'vite.config.ts' and 'vite.dev.config.ts' to be found