### PR TITLE
fix(laravel): update string interpolation

### DIFF
--- a/src/Commands/ExportConfigurationCommand.php
+++ b/src/Commands/ExportConfigurationCommand.php
@@ -24,7 +24,7 @@ class ExportConfigurationCommand extends Command
         if ($path = $this->option('export')) {
             File::put($path, $config);
 
-            $this->info("Configuration file written to <comment>${path}</comment>.");
+            $this->info("Configuration file written to <comment>{$path}</comment>.");
 
             return;
         }

--- a/src/Exceptions/NoSuchConfigurationException.php
+++ b/src/Exceptions/NoSuchConfigurationException.php
@@ -10,7 +10,7 @@ final class NoSuchConfigurationException extends ViteException implements Provid
 {
     public function __construct(protected $configName)
     {
-        $this->message = "Configuration \"${configName}\" does not exist.";
+        $this->message = "Configuration \"{$configName}\" does not exist.";
     }
 
     public function getSolution(): Solution

--- a/src/Exceptions/NoSuchEntrypointException.php
+++ b/src/Exceptions/NoSuchEntrypointException.php
@@ -13,7 +13,7 @@ final class NoSuchEntrypointException extends ViteException implements ProvidesS
         protected ?string $configName = null,
         ?string $message = null,
     ) {
-        $this->message = $message ?? "Entry \"${entry}\" could not be found.";
+        $this->message = $message ?? "Entry \"{$entry}\" could not be found.";
     }
 
     public static function inManifest(string $entry, ?string $configName = null): self
@@ -21,7 +21,7 @@ final class NoSuchEntrypointException extends ViteException implements ProvidesS
         return new self(
             $entry,
             $configName,
-            "Entry \"${entry}\" does not exist in the manifest."
+            "Entry \"{$entry}\" does not exist in the manifest."
         );
     }
 
@@ -30,7 +30,7 @@ final class NoSuchEntrypointException extends ViteException implements ProvidesS
         return new self(
             $entry,
             $configName,
-            "Entry \"${entry}\" could not be found in the configuration."
+            "Entry \"{$entry}\" could not be found in the configuration."
         );
     }
 

--- a/tests/Pest.php
+++ b/tests/Pest.php
@@ -52,7 +52,7 @@ function fixtures_path(string $path = ''): string
 {
     $path = (string) Str::of($path)->start('/');
 
-    return realpath(__DIR__ . "/Fixtures/${path}");
+    return realpath(__DIR__ . "/Fixtures/{$path}");
 }
 
 /**
@@ -68,7 +68,7 @@ function using_manifest(string $path): Configuration
  */
 function get_manifest(string $manifest = 'manifest.json'): Manifest
 {
-    return Manifest::read(fixtures_path("manifests/${manifest}"));
+    return Manifest::read(fixtures_path("manifests/{$manifest}"));
 }
 
 /**
@@ -86,7 +86,7 @@ function set_fixtures_path(string $path = '')
  */
 function set_vite_config(string $name, array $config): void
 {
-    config()->set("vite.configs.${name}", array_replace_recursive(config('vite.configs.default'), $config));
+    config()->set("vite.configs.{$name}", array_replace_recursive(config('vite.configs.default'), $config));
 }
 
 /**


### PR DESCRIPTION
PHP8.2 has deprecated 1 method of string interpolation, and gives the following warning (example):

```
Using ${var} in strings is deprecated, use {$var} instead in /var/www/cmrhk/vendor/innocenzi/laravel-vite/src/Commands/ExportConfigurationCommand.php on line 27
```

More info on the RFC: https://wiki.php.net/rfc/deprecate_dollar_brace_string_interpolation

Several usages of this deprecated method is found in this repo and is therefore changed.